### PR TITLE
add root node_modules to typeroots

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
+      "node_modules/@types",
       "frontend/node_modules/@types"
     ] /* List of folders to include type definitions from. */,
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
In fact, even when using two separate node_modules, this needs to be there
the body-parser is only in the root node_modules
and once app/server.js is generated, subsequent builds will pass without it, so it is easy to miss