### PR TITLE
Disable scrolling page while zooming on altitude chart via scroll wheel

### DIFF
--- a/frontend/src/viewer/components/chart-element.ts
+++ b/frontend/src/viewer/components/chart-element.ts
@@ -604,6 +604,7 @@ export class ChartElement extends connect(store)(LitElement) {
   private handleMouseWheel(e: WheelEvent): void {
     const { timeSec } = this.getCoordinatesFromEvent(e);
     this.dispatchEvent(new CustomEvent('zoom', { detail: { timeSec, deltaY: e.deltaY } }));
+    e.preventDefault();
   }
 
   private handlePointerMove(e: MouseEvent): void {


### PR DESCRIPTION
Le but est de verrouiller le scrolling de la page quand on utilise la roulette sur le graph d'altitude
Je trouve bien pratique de pouvoir zoomer quand on utilise la souris sur le graph mais sur la page CFD (celle qui inclut flyxc dans une iframe) ça n'arrête pas de scroller la page principale en même temps que ça zoom sur la carte et c'est pénible ;) 

**_Note_** : je n'ai pas compilé/testé, j'ai juste vérifié avec une page html bidon contenant une iframe contenant elle même un div avec un preventDefault sur l'évènement mousewheel
A voir donc déjà si déjà le fonctionnement est OK pour toi