### PR TITLE
fix(optimizer): wrong closing radius

### DIFF
--- a/apps/fxc-front/src/app/components/2d/path-element.ts
+++ b/apps/fxc-front/src/app/components/2d/path-element.ts
@@ -258,7 +258,7 @@ export class PathElement extends connect(store)(LitElement) {
 
     if (result.closingPoints) {
       this.closingSector.center = result.closingPoints.in;
-      this.closingSector.radius = score.closingRadiusM;
+      this.closingSector.radius = score.closingRadius * 1000;
       this.closingSector.update();
       this.closingSector.setMap(this.map);
     } else {
@@ -284,7 +284,7 @@ export class PathElement extends connect(store)(LitElement) {
       circuit: result.circuit,
       distanceM: result.lengthKm * 1000,
       multiplier: result.multiplier,
-      closingRadiusM: (result.closingRadiusM ?? 0) * 1000,
+      closingRadius: result.closingRadius ?? 0,
       indexes: result.solutionIndices,
       points: result.score,
     });

--- a/apps/fxc-front/src/app/components/2d/path-element.ts
+++ b/apps/fxc-front/src/app/components/2d/path-element.ts
@@ -258,7 +258,7 @@ export class PathElement extends connect(store)(LitElement) {
 
     if (result.closingPoints) {
       this.closingSector.center = result.closingPoints.in;
-      this.closingSector.radius = score.closingRadiusKm * 1000;
+      this.closingSector.radiusM = score.closingRadiusKm * 1000;
       this.closingSector.update();
       this.closingSector.setMap(this.map);
     } else {

--- a/apps/fxc-front/src/app/components/2d/path-element.ts
+++ b/apps/fxc-front/src/app/components/2d/path-element.ts
@@ -258,7 +258,7 @@ export class PathElement extends connect(store)(LitElement) {
 
     if (result.closingPoints) {
       this.closingSector.center = result.closingPoints.in;
-      this.closingSector.radius = score.closingRadius * 1000;
+      this.closingSector.radius = score.closingRadiusKm * 1000;
       this.closingSector.update();
       this.closingSector.setMap(this.map);
     } else {
@@ -284,7 +284,7 @@ export class PathElement extends connect(store)(LitElement) {
       circuit: result.circuit,
       distanceM: result.lengthKm * 1000,
       multiplier: result.multiplier,
-      closingRadius: result.closingRadius ?? 0,
+      closingRadiusKm: result.closingRadiusKm ?? 0,
       indexes: result.solutionIndices,
       points: result.score,
     });

--- a/apps/fxc-front/src/app/gm/closing-sector.ts
+++ b/apps/fxc-front/src/app/gm/closing-sector.ts
@@ -1,6 +1,6 @@
 export class ClosingSector {
   center: { lat: number; lon: number } | null = null;
-  radius: number | null = null;
+  radiusM: number | null = null;
   circle: google.maps.Circle;
 
   constructor() {
@@ -23,10 +23,10 @@ export class ClosingSector {
   }
 
   update(): void {
-    if (this.center == null || this.radius == null) {
+    if (this.center == null || this.radiusM == null) {
       return;
     }
     this.circle.setCenter({ lat: this.center.lat, lng: this.center.lon });
-    this.circle.setRadius(this.radius);
+    this.circle.setRadius(this.radiusM);
   }
 }

--- a/apps/fxc-front/src/app/logic/score/scorer.ts
+++ b/apps/fxc-front/src/app/logic/score/scorer.ts
@@ -5,7 +5,7 @@ export class Score {
   indexes: number[];
   multiplier: number;
   circuit: CircuitType;
-  closingRadiusM: number;
+  closingRadius: number;
   points: number;
 
   constructor(score: Partial<Score>) {
@@ -13,7 +13,7 @@ export class Score {
     this.indexes = score.indexes ?? [];
     this.multiplier = score.multiplier ?? 1;
     this.circuit = score.circuit ?? CircuitType.OpenDistance;
-    this.closingRadiusM = score.closingRadiusM ?? 0;
+    this.closingRadius = score.closingRadius ?? 0;
     this.points = score.points ?? 0;
   }
 }

--- a/apps/fxc-front/src/app/logic/score/scorer.ts
+++ b/apps/fxc-front/src/app/logic/score/scorer.ts
@@ -5,7 +5,7 @@ export class Score {
   indexes: number[];
   multiplier: number;
   circuit: CircuitType;
-  closingRadius: number;
+  closingRadiusKm: number;
   points: number;
 
   constructor(score: Partial<Score>) {
@@ -13,7 +13,7 @@ export class Score {
     this.indexes = score.indexes ?? [];
     this.multiplier = score.multiplier ?? 1;
     this.circuit = score.circuit ?? CircuitType.OpenDistance;
-    this.closingRadius = score.closingRadius ?? 0;
+    this.closingRadiusKm = score.closingRadiusKm ?? 0;
     this.points = score.points ?? 0;
   }
 }

--- a/libs/optimizer/src/lib/optimizer.spec.ts
+++ b/libs/optimizer/src/lib/optimizer.spec.ts
@@ -235,7 +235,7 @@ describe('optimizer', () => {
       maxNumCycles: 1,
     };
     it('should return a closing distance of 3 km', () => {
-      expect(optimize(request).closingRadius).toEqual(3);
+      expect(optimize(request).closingRadiusKm).toEqual(3);
     });
   });
 
@@ -254,7 +254,7 @@ describe('optimizer', () => {
       maxNumCycles: 1,
     };
     it('should return a closing distance greater than 3 km', () => {
-      expect(optimize(request).closingRadius).toBeGreaterThan(3);
+      expect(optimize(request).closingRadiusKm).toBeGreaterThan(3);
     });
   });
 });

--- a/libs/optimizer/src/lib/optimizer.spec.ts
+++ b/libs/optimizer/src/lib/optimizer.spec.ts
@@ -219,6 +219,44 @@ describe('optimizer', () => {
       optimal: true,
     });
   });
+
+  describe('given a 130.9 triangle with less than 3 km closing distance (FFVL rules)', () => {
+    const tp1 = { lat: 45.20467, lon: 5.72595 };
+    const tp2 = { lat: 45.62463, lon: 6.11006 };
+    const tp3 = { lat: 45.25107, lon: 6.15041 };
+    const tp4 = { lat: 45.20169, lon: 5.74171 };
+    const request: ScoringRequest = {
+      track: mergeTracks(
+        createSegments({ ...tp1, alt: 0, timeSec: 0 }, { ...tp2, alt: 0, timeSec: 60 }, 1),
+        createSegments({ ...tp2, alt: 0, timeSec: 60 }, { ...tp3, alt: 0, timeSec: 120 }, 1),
+        createSegments({ ...tp3, alt: 0, timeSec: 120 }, { ...tp4, alt: 0, timeSec: 180 }, 1),
+      ),
+      ruleName: 'FFVL',
+      maxNumCycles: 1,
+    };
+    it('should return a closing distance of 3 km', () => {
+      expect(optimize(request).closingRadius).toEqual(3);
+    });
+  });
+
+  describe('given a 130.9 triangle with more than 3 km closing distance (FFVL rules)', () => {
+    const tp1 = { lat: 45.20467, lon: 5.72595 };
+    const tp2 = { lat: 45.62463, lon: 6.11006 };
+    const tp3 = { lat: 45.25107, lon: 6.15041 };
+    const tp4 = { lat: 45.1902, lon: 5.78684 };
+    const request: ScoringRequest = {
+      track: mergeTracks(
+        createSegments({ ...tp1, alt: 0, timeSec: 0 }, { ...tp2, alt: 0, timeSec: 60 }, 1),
+        createSegments({ ...tp2, alt: 0, timeSec: 60 }, { ...tp3, alt: 0, timeSec: 120 }, 1),
+        createSegments({ ...tp3, alt: 0, timeSec: 120 }, { ...tp4, alt: 0, timeSec: 180 }, 1),
+      ),
+      ruleName: 'FFVL',
+      maxNumCycles: 1,
+    };
+    it('should return a closing distance greater than 3 km', () => {
+      expect(optimize(request).closingRadius).toBeGreaterThan(3);
+    });
+  });
 });
 
 function optimize(request: ScoringRequest): ScoringResult {

--- a/libs/optimizer/src/lib/optimizer.ts
+++ b/libs/optimizer/src/lib/optimizer.ts
@@ -47,7 +47,7 @@ export interface ScoringResult {
   // Multiplier for computing score. score = lengthKm * multiplier
   multiplier: number;
   circuit?: CircuitType;
-  closingRadius?: number;
+  closingRadiusKm?: number;
   // Indices of solutions points in the request
   solutionIndices: number[];
   // Whether the result is optimal.
@@ -173,7 +173,7 @@ function toOptimizationResult(solution: Solution, track: ScoringTrack): ScoringR
     lengthKm: solution.scoreInfo?.distance ?? 0,
     multiplier: solution.opt.scoring.multiplier,
     circuit: toCircuitType(solution.opt.scoring.code),
-    closingRadius: getClosingRadius(solution),
+    closingRadiusKm: getClosingRadiusKm(solution),
     solutionIndices: getSolutionIndices(solution, track),
     optimal: solution.optimal || false,
     startPoint: solution.scoreInfo?.ep?.start ? pointToLatTon(solution.scoreInfo?.ep?.start) : undefined,
@@ -198,7 +198,7 @@ function pointToLatTon(point: Point): LatLon {
   return { lat: point.y, lon: point.x };
 }
 
-function getClosingRadius(solution: Solution): number | undefined {
+function getClosingRadiusKm(solution: Solution): number | undefined {
   const closingDistance = solution.scoreInfo?.cp?.d;
 
   if (closingDistance == null) {

--- a/libs/optimizer/src/lib/optimizer.ts
+++ b/libs/optimizer/src/lib/optimizer.ts
@@ -47,7 +47,7 @@ export interface ScoringResult {
   // Multiplier for computing score. score = lengthKm * multiplier
   multiplier: number;
   circuit?: CircuitType;
-  closingRadiusM?: number;
+  closingRadius?: number;
   // Indices of solutions points in the request
   solutionIndices: number[];
   // Whether the result is optimal.
@@ -173,7 +173,7 @@ function toOptimizationResult(solution: Solution, track: ScoringTrack): ScoringR
     lengthKm: solution.scoreInfo?.distance ?? 0,
     multiplier: solution.opt.scoring.multiplier,
     circuit: toCircuitType(solution.opt.scoring.code),
-    closingRadiusM: getClosingRadiusM(solution),
+    closingRadius: getClosingRadius(solution),
     solutionIndices: getSolutionIndices(solution, track),
     optimal: solution.optimal || false,
     startPoint: solution.scoreInfo?.ep?.start ? pointToLatTon(solution.scoreInfo?.ep?.start) : undefined,
@@ -198,7 +198,7 @@ function pointToLatTon(point: Point): LatLon {
   return { lat: point.y, lon: point.x };
 }
 
-function getClosingRadiusM(solution: Solution): number | undefined {
+function getClosingRadius(solution: Solution): number | undefined {
   const closingDistance = solution.scoreInfo?.cp?.d;
 
   if (closingDistance == null) {
@@ -209,7 +209,7 @@ function getClosingRadiusM(solution: Solution): number | undefined {
   const closingDistanceFixed = (solution.opt.scoring as any)?.closingDistanceFixed;
 
   if (closingDistanceFixed != null && closingDistance < closingDistanceFixed) {
-    return closingDistanceFixed * 1000;
+    return closingDistanceFixed;
   }
 
   // TODO: remove cast when https://github.com/mmomtchev/igc-xc-score/pull/233 is merged


### PR DESCRIPTION
- wrong radius returned  when having a closing distance computed with relative rule
- closing circle displayed with the wrong scale (expected km but dit not convert m to km)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses two bugs related to the closing radius calculation. It ensures that the closing circle radius is correctly converted from meters to kilometers in the path-element component and fixes the relative closing distance computation by converting it from kilometers to meters in the optimizer library.

* **Bug Fixes**:
    - Fixed the closing circle radius calculation by converting meters to kilometers in the path-element component.
    - Corrected the closing distance computation by converting the relative closing distance from kilometers to meters in the optimizer library.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation of closing sector radius to ensure accurate measurements.

- **Tests**
  - Added new test cases to verify closing distance calculations under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->