### PR TITLE
Fix route length in the planner

### DIFF
--- a/apps/fxc-front/src/app/components/2d/planner-element.ts
+++ b/apps/fxc-front/src/app/components/2d/planner-element.ts
@@ -7,7 +7,7 @@ import { connect } from 'pwa-helpers';
 
 import type { Score } from '../../logic/score/scorer';
 import * as units from '../../logic/units';
-import { decrementSpeed, incrementSpeed, setSpeed } from '../../redux/planner-slice';
+import { decrementSpeed, incrementSpeed, setSpeedKmh } from '../../redux/planner-slice';
 import type { RootState } from '../../redux/store';
 import { store } from '../../redux/store';
 
@@ -25,11 +25,11 @@ export class PlannerElement extends connect(store)(LitElement) {
   @state()
   private score?: Score;
   @state()
-  private speed = 20;
+  private speedKmh = 20;
   @state()
   private units?: units.Units;
   @state()
-  private distance = 0;
+  private distanceM = 0;
   @state()
   private hideDetails = store.getState().browser.isSmallScreen;
   @state()
@@ -44,11 +44,11 @@ export class PlannerElement extends connect(store)(LitElement) {
   private readonly drawHandler = () => this.dispatchEvent(new CustomEvent('draw-route'));
 
   stateChanged(state: RootState): void {
-    this.distance = state.planner.distance;
+    this.distanceM = state.planner.distanceM;
     this.score = state.planner.score;
-    this.speed = state.planner.speed;
+    this.speedKmh = state.planner.speedKmh;
     this.units = state.units;
-    this.duration = ((this.distance / this.speed) * 60) / 1000;
+    this.duration = ((this.distanceM / this.speedKmh) * 60) / 1000;
     this.isFreeDrawing = state.planner.isFreeDrawing;
   }
 
@@ -151,7 +151,7 @@ export class PlannerElement extends connect(store)(LitElement) {
         <div class="collapsible">
           <div>Total distance</div>
           <div class="large">
-            ${unsafeHTML(units.formatUnit(this.distance / 1000, this.units.distance, undefined, 'unit'))}
+            ${unsafeHTML(units.formatUnit(this.distanceM / 1000, this.units.distance, undefined, 'unit'))}
           </div>
         </div>
         <div
@@ -182,7 +182,7 @@ export class PlannerElement extends connect(store)(LitElement) {
             </div>
           </div>
           <div class="large">
-            ${unsafeHTML(units.formatUnit(this.speed as number, this.units.speed, undefined, 'unit'))}
+            ${unsafeHTML(units.formatUnit(this.speedKmh as number, this.units.speed, undefined, 'unit'))}
           </div>
         </div>
         <div
@@ -242,13 +242,13 @@ export class PlannerElement extends connect(store)(LitElement) {
     const width = target.clientWidth;
     const delta = x > width / 2 ? 1 : -1;
     const duration = (Math.floor((this.duration as number) / 15) + delta) * 15;
-    store.dispatch(setSpeed(this.distance / ((1000 * Math.max(15, duration)) / 60)));
+    store.dispatch(setSpeedKmh(this.distanceM / ((1000 * Math.max(15, duration)) / 60)));
   }
 
   private wheelDuration(e: WheelEvent): void {
     const delta = Math.sign(e.deltaY);
     const duration = (Math.floor((this.duration as number) / 15) + delta) * 15;
-    store.dispatch(setSpeed(this.distance / ((1000 * Math.max(15, duration)) / 60)));
+    store.dispatch(setSpeedKmh(this.distanceM / ((1000 * Math.max(15, duration)) / 60)));
   }
 
   private changeSpeed(e: MouseEvent): void {

--- a/apps/fxc-front/src/app/pages/admin.ts
+++ b/apps/fxc-front/src/app/pages/admin.ts
@@ -113,7 +113,7 @@ export class AdminPage extends LitElement {
             <ion-button @click=${this.fetch}>Refresh</ion-button>
           </ion-buttons>
           <ion-buttons slot="secondary">
-            <ion-button @click="${async () => await this.logout()})">Logout</ion-button>
+            <ion-button @click="${async () => await this.logout()}">Logout</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-footer>`;

--- a/apps/fxc-front/src/app/pages/admin.ts
+++ b/apps/fxc-front/src/app/pages/admin.ts
@@ -113,7 +113,7 @@ export class AdminPage extends LitElement {
             <ion-button @click=${this.fetch}>Refresh</ion-button>
           </ion-buttons>
           <ion-buttons slot="secondary">
-            <ion-button @click="${async () => await this.logout()}">Logout</ion-button>
+            <ion-button @click="${() => this.logout()}">Logout</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-footer>`;

--- a/apps/fxc-front/src/app/redux/planner-slice.ts
+++ b/apps/fxc-front/src/app/redux/planner-slice.ts
@@ -7,8 +7,9 @@ import type { Score } from '../logic/score/scorer';
 
 export type PlannerState = {
   score?: Score;
-  speed: number;
-  distance: number;
+  speedKmh: number;
+  // Total length of the path.
+  distanceM: number;
   league: LeagueCode;
   enabled: boolean;
   // Encoded route.
@@ -21,8 +22,8 @@ const enabled = route.length > 0;
 
 const initialState: PlannerState = {
   score: undefined,
-  speed: Number(getUrlParamValues(ParamNames.speed)[0] ?? 20),
-  distance: 0,
+  speedKmh: Number(getUrlParamValues(ParamNames.speed)[0] ?? 20),
+  distanceM: 0,
   league: (getUrlParamValues(ParamNames.league)[0] ?? localStorage.getItem('league') ?? 'xc') as LeagueCode,
   enabled,
   route,
@@ -36,12 +37,12 @@ const plannerSlice = createSlice({
     setScore: (state, action: PayloadAction<Score | undefined>) => {
       state.score = action.payload;
     },
-    setDistance: (state, action: PayloadAction<number>) => {
-      state.distance = action.payload;
+    setDistanceM: (state, action: PayloadAction<number>) => {
+      state.distanceM = action.payload;
     },
-    setSpeed: (state, action: PayloadAction<number>) => {
-      state.speed = Math.max(1, action.payload);
-      setUrlParamValue(ParamNames.speed, state.speed.toFixed(1));
+    setSpeedKmh: (state, action: PayloadAction<number>) => {
+      state.speedKmh = Math.max(1, action.payload);
+      setUrlParamValue(ParamNames.speed, state.speedKmh.toFixed(1));
     },
     setLeague: (state, action: PayloadAction<LeagueCode>) => {
       setUrlParamValue(ParamNames.league, action.payload);
@@ -49,12 +50,12 @@ const plannerSlice = createSlice({
       state.league = action.payload;
     },
     incrementSpeed: (state) => {
-      state.speed = Math.floor(state.speed + 1);
-      setUrlParamValue(ParamNames.speed, state.speed.toFixed(1));
+      state.speedKmh = Math.floor(state.speedKmh + 1);
+      setUrlParamValue(ParamNames.speed, state.speedKmh.toFixed(1));
     },
     decrementSpeed: (state) => {
-      state.speed = Math.max(1, Math.floor(state.speed - 1));
-      setUrlParamValue(ParamNames.speed, state.speed.toFixed(1));
+      state.speedKmh = Math.max(1, Math.floor(state.speedKmh - 1));
+      setUrlParamValue(ParamNames.speed, state.speedKmh.toFixed(1));
     },
     setRoute: (state, action: PayloadAction<string>) => {
       const route = action.payload;
@@ -77,8 +78,8 @@ const plannerSlice = createSlice({
 export const reducer = plannerSlice.reducer;
 export const {
   setScore,
-  setDistance,
-  setSpeed,
+  setDistanceM,
+  setSpeedKmh,
   setLeague,
   incrementSpeed,
   decrementSpeed,

--- a/apps/fxc-front/src/flyxc.ts
+++ b/apps/fxc-front/src/flyxc.ts
@@ -170,7 +170,7 @@ export class FlyXc extends connect(store)(LitElement) {
 
     // Update the route and speed.
     store.dispatch(planner.setRoute(getUrlParamValues(ParamNames.route)[0] ?? ''));
-    store.dispatch(planner.setSpeed(Number(getUrlParamValues(ParamNames.speed)[0] ?? 20)));
+    store.dispatch(planner.setSpeedKmh(Number(getUrlParamValues(ParamNames.speed)[0] ?? 20)));
   }
 
   // Load tracks dropped on the map.


### PR DESCRIPTION
Thanks Brian Black for the report

/cc @flyingtof

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the route length calculation in the planner by ensuring the distance is measured in meters and speed in km/h. It also includes refactoring for clarity and a minor syntax fix in the admin page.

* **Bug Fixes**:
    - Corrected the route length calculation in the planner by ensuring the distance is measured in meters and speed in km/h.
* **Enhancements**:
    - Refactored variable names for clarity, changing 'speed' to 'speedKmh' and 'distance' to 'distanceM' across the planner-related components and state management.
* **Chores**:
    - Fixed a minor syntax error in the admin page's logout button.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the "Logout" button click handler to properly call the `logout` method asynchronously.

- **Refactor**
  - Renamed `speed` to `speedKmh` and `distance` to `distanceM` for consistency and clarity.
  - Updated all relevant calculations and dispatches to use the new property names.

- **Improvements**
  - Enhanced path vertex removal functionality on right-click and double-click events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->