### PR TITLE
Add IGN France tiles to the 3D view

### DIFF
--- a/apps/fxc-front/src/app/components/3d/map3d-element.ts
+++ b/apps/fxc-front/src/app/components/3d/map3d-element.ts
@@ -69,6 +69,7 @@ export class Map3dElement extends connect(store)(LitElement) {
     Satellite: null,
     Google: null,
     OpenTopoMap: null,
+    IgnFr: null,
     Topo: 'topo-3d',
   };
 
@@ -321,6 +322,18 @@ export class Map3dElement extends connect(store)(LitElement) {
       ],
       title: 'otm',
       id: 'otm',
+    });
+
+    this.basemaps.IgnFr = new Basemap({
+      baseLayers: [
+        new WebTileLayer({
+          urlTemplate:
+            'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&STYLE=normal&FORMAT=image/png&TILEMATRIXSET=PM&TILEMATRIX={level}&TILEROW={row}&TILECOL={col}',
+          copyright: 'Map tiles by <a href="https://ign.fr/">©IGN</a>',
+        }),
+      ],
+      title: 'IGN',
+      id: 'ignfr',
     });
 
     this.basemaps.Google = new Basemap({


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature that adds support for IGN France tiles in the 3D view. A new basemap configuration for IGN France has been added to the map3d-element component.

* **New Features**:
    - Added support for IGN France tiles in the 3D view, including a new basemap configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new basemap named `IgnFr` to the 3D map component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->