### PR TITLE
Handle beforeinstallprompt early

### DIFF
--- a/apps/fxc-front/index.html
+++ b/apps/fxc-front/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" class="hydrated">
   <head>
+    <script>
+      addEventListener('beforeinstallprompt', (e) => {
+        e.preventDefault();
+        window.deferredPrompt = e;
+      });
+    </script>
     <title>flyXC</title>
     <meta
       name="description"

--- a/apps/fxc-front/src/app/components/pwa-install.ts
+++ b/apps/fxc-front/src/app/components/pwa-install.ts
@@ -49,7 +49,18 @@ export class PWAInstallComponent extends LitElement {
   @property({ type: String }) cancelbuttontext = 'Cancel';
   @property({ type: String }) iosinstallinfotext = "Tap the share button and then 'Add to Homescreen'";
 
-  @property() deferredprompt: any;
+  // type: BeforeInstallPromptEvent
+  private _deferredprompt?: any;
+
+  // Used when the event triggered before the component was instantiated.
+  @property({ attribute: false })
+  set deferredprompt(e: Event) {
+    this._deferredprompt ??= e;
+  }
+
+  get deferredprompt(): Event | undefined {
+    return this._deferredprompt;
+  }
 
   static get styles() {
     return css`
@@ -630,7 +641,7 @@ export class PWAInstallComponent extends LitElement {
   }
 
   handleInstallPromptEvent(event: Event): void {
-    this.deferredprompt = event;
+    this._deferredprompt = event;
 
     this.hasprompt = true;
 
@@ -713,12 +724,12 @@ export class PWAInstallComponent extends LitElement {
   }
 
   async install(): Promise<boolean> {
-    if (this.deferredprompt) {
-      this.deferredprompt.prompt();
+    if (this._deferredprompt) {
+      this._deferredprompt.prompt();
 
       this.dispatchEvent(new CustomEvent('show'));
 
-      const choiceResult = await this.deferredprompt.userChoice;
+      const choiceResult = await this._deferredprompt.userChoice;
 
       if (choiceResult.outcome === 'accepted') {
         console.log('Your PWA has been installed');
@@ -854,7 +865,7 @@ export class PWAInstallComponent extends LitElement {
                   () =>
                     html`<div id="buttonsContainer">
                       ${when(
-                        this.deferredprompt,
+                        this._deferredprompt,
                         () => html`<button id="installButton" @click="${this.install}">
                           ${this.installbuttontext} ${this.manifestdata.short_name}
                         </button>`,

--- a/apps/fxc-front/src/env.d.ts
+++ b/apps/fxc-front/src/env.d.ts
@@ -22,4 +22,7 @@ interface ImportMeta {
 declare global {
   const __BUILD_TIMESTAMP__: string;
   const __AIRSPACE_DATE__: string;
+  interface Window {
+    deferredPrompt: Event;
+  }
 }

--- a/apps/fxc-front/src/flyxc.ts
+++ b/apps/fxc-front/src/flyxc.ts
@@ -130,6 +130,7 @@ export class FlyXc extends connect(store)(LitElement) {
             'Plan your routes',
             'Aggregate your live tracking positions from the major platforms',
           ]}
+          .deferredprompt=${window.deferredPrompt}
           @hide=${this.cancelInstall}
         ></pwa-install>`,
       )}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactored the PWAInstallComponent to handle the 'beforeinstallprompt' event more robustly by capturing and storing the event even if it occurs before the component is instantiated. This ensures the prompt can be accessed and used later in the component lifecycle.

* **Enhancements**:
    - Refactored the handling of the 'beforeinstallprompt' event to ensure it is captured and stored even if triggered before the component is instantiated.

<!-- Generated by sourcery-ai[bot]: end summary -->