### PR TITLE
Use shallow clones in actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,10 @@ jobs:
         node-version: [20.x]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/upload-windy-sounding.yml
+++ b/.github/workflows/upload-windy-sounding.yml
@@ -10,6 +10,10 @@ jobs:
       WINDY_API_KEY: '${{ secrets.WINDY_API_KEY }}'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
       - name: Build
         run: |
           npm install


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflows to use shallow clones with a fetch depth of 2. This change aims to improve the efficiency of the CI process and ensure that pull request heads are properly checked out.

- **CI**:
    - Updated GitHub Actions workflows to use shallow clones with a fetch depth of 2 to improve efficiency and ensure proper checkout of pull request heads.

<!-- Generated by sourcery-ai[bot]: end summary -->