### PR TITLE
Disable the install screen

### DIFF
--- a/apps/fxc-front/src/flyxc.ts
+++ b/apps/fxc-front/src/flyxc.ts
@@ -61,8 +61,9 @@ export class FlyXc extends connect(store)(LitElement) {
 
   private showPwaInstall = false;
 
-  stateChanged(state: RootState): void {
-    this.showPwaInstall = !state.app.pwaInstallCancelled && !state.browser.isInIframe;
+  stateChanged(): void {
+    // TODO(vicb): install screen is confusing
+    // this.showPwaInstall = !state.app.pwaInstallCancelled && !state.browser.isInIframe;
   }
 
   constructor() {


### PR DESCRIPTION
It confuses a lot of users

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Disabled the PWA install screen by commenting out the logic that determines its visibility, as it was causing confusion among users.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the PWA install prompt was shown under incorrect conditions.

- **Refactor**
  - Simplified the `stateChanged` method to improve code readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->