### PR TITLE
Added correct closingDistanceRelative for Czech leagues

### DIFF
--- a/libs/optimizer/src/lib/optimizer.spec.ts
+++ b/libs/optimizer/src/lib/optimizer.spec.ts
@@ -257,6 +257,31 @@ describe('optimizer', () => {
       expect(optimize(request).closingRadiusKm).toBeGreaterThan(3);
     });
   });
+
+  ([
+    'CzechLocal',
+    'CzechEurope',
+    'CzechOutsideEurope',
+  ] as ScoringRuleName[]).forEach((rule) => {
+    describe(`given a 130.9 triangle with more than 3 km closing distance (${rule} rules)`, () => {
+      const tp1 = { lat: 45.20467, lon: 5.72595 };
+      const tp2 = { lat: 45.62463, lon: 6.11006 };
+      const tp3 = { lat: 45.25107, lon: 6.15041 };
+      const tp4 = { lat: 45.1902, lon: 5.78684 };
+      const request: ScoringRequest = {
+        track: mergeTracks(
+          createSegments({ ...tp1, alt: 0, timeSec: 0 }, { ...tp2, alt: 0, timeSec: 60 }, 1),
+          createSegments({ ...tp2, alt: 0, timeSec: 60 }, { ...tp3, alt: 0, timeSec: 120 }, 1),
+          createSegments({ ...tp3, alt: 0, timeSec: 120 }, { ...tp4, alt: 0, timeSec: 180 }, 1),
+        ),
+        ruleName: rule,
+        maxNumCycles: 1,
+      };
+      it('should return a closing distance less than 20 km', () => {
+        expect(optimize(request).closingRadiusKm).toBeLessThan(20);
+      });
+    });
+  });
 });
 
 function optimize(request: ScoringRequest): ScoringResult {

--- a/libs/optimizer/src/lib/scoring-rules.ts
+++ b/libs/optimizer/src/lib/scoring-rules.ts
@@ -9,6 +9,8 @@ const freeTriangle = scoringBaseModel[1];
 const faiTriangle = scoringBaseModel[2];
 const outAndReturn = igcXcScore.scoringRules['FAI-OAR'][0];
 
+//Czech rules see https://www.xcontest.org/cesko/pravidla/
+
 const czechLocalRule = [
   { ...openDistance, multiplier: 1 },
   { ...freeTriangle, multiplier: 1.8, closingDistanceRelative: 0.05 },

--- a/libs/optimizer/src/lib/scoring-rules.ts
+++ b/libs/optimizer/src/lib/scoring-rules.ts
@@ -11,20 +11,20 @@ const outAndReturn = igcXcScore.scoringRules['FAI-OAR'][0];
 
 const czechLocalRule = [
   { ...openDistance, multiplier: 1 },
-  { ...freeTriangle, multiplier: 1.8 },
-  { ...faiTriangle, multiplier: 2.2 },
+  { ...freeTriangle, multiplier: 1.8, closingDistanceRelative: 0.05 },
+  { ...faiTriangle, multiplier: 2.2, closingDistanceRelative: 0.05 },
 ];
 
 const czechEuropeRule = [
   { ...openDistance, multiplier: 1 },
-  { ...freeTriangle, multiplier: 1.2 },
-  { ...faiTriangle, multiplier: 1.4 },
+  { ...freeTriangle, multiplier: 1.2, closingDistanceRelative: 0.05 },
+  { ...faiTriangle, multiplier: 1.4, closingDistanceRelative: 0.05 },
 ];
 
 const czechOutEuropeRule = [
   { ...openDistance, multiplier: 0.8 },
-  { ...freeTriangle, multiplier: 1.2 },
-  { ...faiTriangle, multiplier: 1.4 },
+  { ...freeTriangle, multiplier: 1.2, closingDistanceRelative: 0.05 },
+  { ...faiTriangle, multiplier: 1.4, closingDistanceRelative: 0.05 },
 ];
 
 const leonardoRule = [


### PR DESCRIPTION
Hi Victor, 
recently the flyxc.app started to show wrong closing circle for Czech leagues. I suspect that the default value for closing was changed and there is not set the value in definition of Czech leagues.

Here's a PR stating the correct value of 5% for all the triangles.

Karel

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the incorrect closing circle distance for Czech leagues by setting the closingDistanceRelative value to 5% for all triangle types in the scoring rules.

- **Bug Fixes**:
    - Corrected the closing distance relative value for Czech leagues to 5% for all triangle types.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved scoring rules for triangle categories with a new `closingDistanceRelative` parameter.
- **Enhancements**
	- Adjusted scoring multipliers for `freeTriangle` and `faiTriangle` under various rule sets for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->