### PR TITLE
Update spot feed support URL

### DIFF
--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -157,7 +157,7 @@ export class SettingsPage extends LitElement {
                   .hint=${html`<ion-text class="ion-padding-horizontal ion-padding-top block">
                     Create an XML feed by following the instructions on this
                     <a
-                      href="https://www.findmespot.com/en-us/support/spot-trace/get-help/general/spot-api-support"
+                      href="https://www.findmespot.com/en-us/support/spot-gen4/get-help/general/public-api-and-xml-feed"
                       target="_blank"
                       >page</a
                     >


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Updated the URL for creating an XML feed in the settings page to point to the new support page for Spot Gen4.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the URL link in the Settings page to direct users to the correct page for creating an XML feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->