### PR TITLE
Throttle FFVL

### DIFF
--- a/apps/fxc-front/src/app/components/2d/map-element.ts
+++ b/apps/fxc-front/src/app/components/2d/map-element.ts
@@ -230,7 +230,7 @@ export class MapElement extends connect(store)(LitElement) {
         this.map.addListener('center_changed', () => this.handleLocation());
 
         // Zoom to the track the first time the document becomes visible.
-        if (document.visibilityState != 'visible') {
+        if (document.visibilityState !== 'visible') {
           document.addEventListener('visibilitychange', () => this.zoomToTracks(), { once: true });
         }
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a throttling mechanism for loading Google Maps, adding a 20-second delay for FFVL browsers to improve performance and user experience. The rest of the map initialization logic remains unchanged.

- **Enhancements**:
    - Introduced a delay mechanism for loading Google Maps based on the browser type, adding a 20-second delay for FFVL browsers.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved loading times for Google Maps based on browser type.
  - Enhanced map interaction with new controls and an advertisement (if applicable).
  - Refined zoom logic based on track presence and map center changes.
  - Added event listener for visibility changes to trigger zooming to tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->