### PR TITLE
Bump the throttle to 50s

### DIFF
--- a/apps/fxc-front/src/app/components/2d/map-element.ts
+++ b/apps/fxc-front/src/app/components/2d/map-element.ts
@@ -153,7 +153,7 @@ export class MapElement extends connect(store)(LitElement) {
       .then(() => {
         return new Promise<void>((resolve) => {
           const throttle = store.getState().browser.isFromFfvl;
-          setTimeout(() => resolve(), throttle ? 20 * 1000 : 0);
+          setTimeout(() => resolve(), throttle ? 50 * 1000 : 0);
         });
       })
       .then((): void => {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request increases the throttle delay for the map element from 20 seconds to 50 seconds when the browser state indicates it is from FFVL, enhancing the user experience by reducing the frequency of updates.

- **Enhancements**:
    - Increased the throttle delay from 20 seconds to 50 seconds for the map element when the browser state indicates it is from FFVL.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Increased timeout delay for map elements from 20 to 50 seconds to improve performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->