### PR TITLE
Add an option to get 48h of live data history

### DIFF
--- a/apps/fetcher/src/app/trackers/flymaster.ts
+++ b/apps/fetcher/src/app/trackers/flymaster.ts
@@ -6,7 +6,7 @@ import type { protos, TrackerNames } from '@flyxc/common';
 import {
   fetchResponse,
   formatReqError,
-  LIVE_MINIMAL_INTERVAL_SEC,
+  LiveDataIntervalSec,
   removeBeforeFromLiveTrack,
   simplifyLiveTrack,
   validateFlymasterAccount,
@@ -79,7 +79,7 @@ export class FlymasterFetcher extends TrackerFetcher {
         const points = parse(flight);
         let track = makeLiveTrack(points);
         track = removeBeforeFromLiveTrack(track, fetchSecond - 300);
-        simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+        simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
         updates.trackerDeltas.set(dsId, track);
       });
 

--- a/apps/fetcher/src/app/trackers/inreach.ts
+++ b/apps/fetcher/src/app/trackers/inreach.ts
@@ -9,7 +9,7 @@ import {
   fetchResponse,
   formatReqError,
   Keys,
-  LIVE_MINIMAL_INTERVAL_SEC,
+  LiveDataIntervalSec,
   parallelTasksWithTimeout,
   parseRetryAfterS,
   protos,
@@ -91,7 +91,7 @@ export class InreachFetcher extends TrackerFetcher {
           try {
             const points = parse(await response.text());
             const track = makeLiveTrack(points);
-            simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+            simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
             if (track.timeSec.length > 0) {
               updates.trackerDeltas.set(id, track);
             }

--- a/apps/fetcher/src/app/trackers/skylines.ts
+++ b/apps/fetcher/src/app/trackers/skylines.ts
@@ -7,7 +7,7 @@ import {
   decodeDeltas,
   fetchResponse,
   formatReqError,
-  LIVE_MINIMAL_INTERVAL_SEC,
+  LiveDataIntervalSec,
   removeBeforeFromLiveTrack,
   simplifyLiveTrack,
   validateSkylinesAccount,
@@ -61,7 +61,7 @@ export class SkylinesFetcher extends TrackerFetcher {
               const points = parse(flight);
               let track = makeLiveTrack(points);
               track = removeBeforeFromLiveTrack(track, keepFromSec);
-              simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+              simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
               updates.trackerDeltas.set(dsId, track);
             });
             [...sklIdToDsId.values()].forEach((id) => updates.fetchedTracker.add(id));

--- a/apps/fetcher/src/app/trackers/spot.ts
+++ b/apps/fetcher/src/app/trackers/spot.ts
@@ -6,7 +6,7 @@ import type { protos, TrackerNames } from '@flyxc/common';
 import {
   fetchResponse,
   formatReqError,
-  LIVE_MINIMAL_INTERVAL_SEC,
+  LiveDataIntervalSec,
   simplifyLiveTrack,
   validateSpotAccount,
 } from '@flyxc/common';
@@ -43,7 +43,7 @@ export class SpotFetcher extends TrackerFetcher {
           try {
             const points = parse(await response.text());
             const track = makeLiveTrack(points);
-            simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+            simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
             if (track.timeSec.length > 0) {
               updates.trackerDeltas.set(id, track);
             }

--- a/apps/fetcher/src/app/trackers/tracker.ts
+++ b/apps/fetcher/src/app/trackers/tracker.ts
@@ -1,7 +1,7 @@
 // Base class for fetching tracker updates.
 
 import type { protos, TrackerNames } from '@flyxc/common';
-import { LIVE_REFRESH_SEC, LIVE_TRACKER_RETENTION_SEC } from '@flyxc/common';
+import { LIVE_REFRESH_SEC, TRACKERS_MAX_FETCH_DURATION_SEC } from '@flyxc/common';
 import type { ChainableCommander } from 'ioredis';
 
 // Updates for a tick of a tracker type (InReach, Spot, ...).
@@ -123,7 +123,7 @@ export class TrackerFetcher {
     const tracker = this.getTracker(id);
     const nowSec = Math.round(Date.now() / 1000);
     const lastFetchSec = tracker ? tracker.lastFetchSec : nowSec;
-    return Math.max(startSec - LIVE_TRACKER_RETENTION_SEC, lastFetchSec - paddingSec);
+    return Math.max(startSec - TRACKERS_MAX_FETCH_DURATION_SEC, lastFetchSec - paddingSec);
   }
 
   // Counts the number of requests and errors.

--- a/apps/fetcher/src/app/trackers/xcontest.ts
+++ b/apps/fetcher/src/app/trackers/xcontest.ts
@@ -6,8 +6,8 @@ import type { protos, TrackerNames } from '@flyxc/common';
 import {
   fetchResponse,
   formatReqError,
-  LIVE_TRACKER_RETENTION_SEC,
   parallelTasksWithTimeout,
+  TRACKERS_MAX_FETCH_DURATION_SEC,
   validateXContestAccount,
 } from '@flyxc/common';
 import { Secrets } from '@flyxc/secrets';
@@ -41,7 +41,7 @@ export class XcontestFetcher extends TrackerFetcher {
     const xcontestIdToLastFlight = new Map<string, XContestFlight>();
 
     // Get all the users for the retention period
-    const openTimeMs = new Date().getTime() - LIVE_TRACKER_RETENTION_SEC * 1000;
+    const openTimeMs = new Date().getTime() - TRACKERS_MAX_FETCH_DURATION_SEC * 1000;
 
     const liveUserUrl =
       `https://api.xcontest.org/livedata/users?entity=group:flyxc&source=live&opentime={openTimeISO}`.replace(

--- a/apps/fetcher/src/app/ufos/refresh.ts
+++ b/apps/fetcher/src/app/ufos/refresh.ts
@@ -2,8 +2,8 @@ import type { protos } from '@flyxc/common';
 import {
   Keys,
   LIVE_FETCH_TIMEOUT_SEC,
-  LIVE_MINIMAL_INTERVAL_SEC,
-  LIVE_UFO_RETENTION_SEC,
+  LiveDataIntervalSec,
+  LiveDataRetentionSec,
   mergeLiveTracks,
   removeBeforeFromLiveTrack,
   simplifyLiveTrack,
@@ -32,23 +32,23 @@ export async function resfreshUfoFleets(pipeline: ChainableCommander, state: pro
   }
 
   const nowSec = Math.round(Date.now() / 1000);
-  const ufoStartSec = nowSec - LIVE_UFO_RETENTION_SEC;
+  const ufoStartSec = nowSec - LiveDataRetentionSec.Ufo;
 
   for (const fleetUpdate of fleetUpdates) {
-    const fleetName = fleetUpdate.fleetName;
+    const { fleetName } = fleetUpdate;
     const ufoTracks = state.ufoFleets[fleetName].ufos ?? {};
 
-    for (const [id, livetrack] of fleetUpdate.deltas.entries()) {
+    for (const [id, track] of fleetUpdate.deltas.entries()) {
       if (ufoTracks[id] != null) {
-        ufoTracks[id] = mergeLiveTracks(ufoTracks[id], livetrack);
+        ufoTracks[id] = mergeLiveTracks(ufoTracks[id], track);
       } else {
-        ufoTracks[id] = livetrack;
+        ufoTracks[id] = track;
       }
     }
 
     // eslint-disable-next-line prefer-const
     for (let [id, track] of Object.entries(ufoTracks)) {
-      simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+      simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
       track = removeBeforeFromLiveTrack(track, ufoStartSec);
       if (track.timeSec.length == 0) {
         delete ufoTracks[id];

--- a/apps/fxc-front/src/app/components/ui/main-menu.ts
+++ b/apps/fxc-front/src/app/components/ui/main-menu.ts
@@ -723,9 +723,10 @@ export class LiveTrackItems extends connect(store)(LitElement) {
           value=${this.historyMin}
           @ionChange=${this.handleHistory}
         >
-          <ion-select-option value=${40}>40mn</ion-select-option>
+          <ion-select-option value=${40}>40min</ion-select-option>
           <ion-select-option value=${12 * 60}>12h</ion-select-option>
           <ion-select-option value=${24 * 60}>24h</ion-select-option>
+          <ion-select-option value=${48 * 60}>48h</ion-select-option>
         </ion-select>
       </ion-item> `;
   }

--- a/apps/fxc-front/src/app/components/ui/supporter-modal.ts
+++ b/apps/fxc-front/src/app/components/ui/supporter-modal.ts
@@ -33,7 +33,9 @@ export class SupporterModal extends LitElement {
             flyXC (formerly VisuGps) has always been
             <a href="https://github.com/vicb/visugps" target="_blank">open-source</a> and free to use since 2007.
           </p>
-          <p>The development effort represents hundreds of hours per year and hosting flyXC costs about $10 a month.</p>
+          <p>
+            The development effort represents hundreds of hours per year and hosting flyXC costs around $10 a month.
+          </p>
           <p>
             If you can afford it, please consider supporting flyXC with a small donation by clicking the button below.
             It will help keep me motivated to maintain and improve it.

--- a/apps/fxc-front/src/app/logic/live-track.ts
+++ b/apps/fxc-front/src/app/logic/live-track.ts
@@ -6,7 +6,7 @@ import {
   isEmergencyTrack,
   IsSimplifiableFix,
   isUfo,
-  LIVE_MINIMAL_INTERVAL_SEC,
+  LiveDataIntervalSec,
   mergeLiveTracks,
   simplifyLiveTrack,
 } from '@flyxc/common';
@@ -210,7 +210,7 @@ export function updateLiveTracks(
       }
       if (id in updatedTracks) {
         track = mergeLiveTracks(track, updatedTracks[id]);
-        simplifyLiveTrack(track, LIVE_MINIMAL_INTERVAL_SEC);
+        simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
       }
       updatedTracks[id] = track;
     }

--- a/apps/fxc-front/src/app/pages/admin.ts
+++ b/apps/fxc-front/src/app/pages/admin.ts
@@ -178,7 +178,7 @@ export class DashSummary extends LitElement {
   }
 
   render(): TemplateResult {
-    const trackerM20 = this.values[common.Keys.fetcherLongIncrementalNumTracks];
+    const trackerM20 = this.values[common.Keys.fetcherIncrementalNumTracksLong];
     const nextStopSec = this.values[common.Keys.fetcherNextStopSec];
     const lastStopSec = this.values[common.Keys.fetcherStoppedSec];
 
@@ -198,7 +198,7 @@ export class DashSummary extends LitElement {
           this.values[common.Keys.trackerNum],
           'https://console.cloud.google.com/datastore/entities;kind=LiveTrack;ns=__$DEFAULT$__;sortCol=created;sortDir=DESCENDING/query/kind?project=fly-xc',
         )}
-        ${singleLineItem('Trackers h24', this.values[common.Keys.fetcherFullNumTracks])}
+        ${singleLineItem('Trackers h24', this.values[common.Keys.fetcherFullNumTracksH24])}
         ${singleLineItem('Trackers m20', trackerM20)}
         ${singleLineItem(
           'Last device updated',

--- a/apps/fxc-front/src/app/pages/privacy-policy.ts
+++ b/apps/fxc-front/src/app/pages/privacy-policy.ts
@@ -72,7 +72,7 @@ export class PrivacyPolicyPage extends LitElement {
           </p>
           <p>
             We collect your registered tracker positions continuously and use that to display your position on the map
-            for up to 24 hours. By signing up for flyXC and registering your tracker devices, you acknowledge and agree
+            for up to 48 hours. By signing up for flyXC and registering your tracker devices, you acknowledge and agree
             that your tracker devices location will be displayed and viewable via our services.
           </p>
           <p>

--- a/apps/fxc-front/src/app/redux/live-track-slice.ts
+++ b/apps/fxc-front/src/app/redux/live-track-slice.ts
@@ -99,7 +99,8 @@ export const updateTrackers = createAsyncThunk('liveTrack/fetch', async (_: unde
   try {
     const state = (api.getState() as RootState).liveTrack;
     const timeSec = Math.round((state.fetchMillis ?? 0) / 1000);
-    const response = await fetch(`${import.meta.env.VITE_API_SERVER}/api/live/tracks.pbf?s=${timeSec}`);
+    const fetchMin = Math.round(state.historyMin);
+    const response = await fetch(`${import.meta.env.VITE_API_SERVER}/api/live/tracks.pbf?s=${timeSec}&fm=${fetchMin}`);
     if (response.status === 200) {
       const tracks = state.tracks.entities;
       trackWorker.postMessage({

--- a/apps/fxc-front/src/app/workers/live-track.ts
+++ b/apps/fxc-front/src/app/workers/live-track.ts
@@ -1,6 +1,6 @@
 // Process the live tracking info from the server.
 
-import { isUfo, LIVE_UFO_RETENTION_SEC, protos, removeBeforeFromLiveTrack, TRACK_GAP_MIN } from '@flyxc/common';
+import { isUfo, LiveDataRetentionSec, protos, removeBeforeFromLiveTrack, TRACK_GAP_MIN } from '@flyxc/common';
 
 import { trackToFeatures, updateLiveTracks } from '../logic/live-track';
 
@@ -29,7 +29,7 @@ w.addEventListener('message', (message: MessageEvent<Request>) => {
   const now = Math.round(Date.now() / 1000);
 
   for (let track of updatedTracks) {
-    const dropBeforeSec = now - (isUfo(track.flags[0]) ? LIVE_UFO_RETENTION_SEC : historySec);
+    const dropBeforeSec = now - (isUfo(track.flags[0]) ? LiveDataRetentionSec.Ufo : historySec);
     track = removeBeforeFromLiveTrack(track, dropBeforeSec);
 
     if (track.timeSec.length > 0) {

--- a/apps/fxc-server/src/app/routes/admin.ts
+++ b/apps/fxc-server/src/app/routes/admin.ts
@@ -144,8 +144,8 @@ async function getDashboardValues(redis: Redis, datastore: Datastore): Promise<u
     [Keys.hostMemoryUsedMb]: 'S',
     [Keys.hostMemoryTotalMb]: 'S',
     [Keys.hostNode]: 'S',
-    [Keys.fetcherFullNumTracks]: 'S',
-    [Keys.fetcherLongIncrementalNumTracks]: 'S',
+    [Keys.fetcherFullNumTracksH24]: 'S',
+    [Keys.fetcherIncrementalNumTracksLong]: 'S',
     [Keys.trackerNum]: 'S',
     [Keys.trackNum]: 'S',
 

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -61,7 +61,7 @@ export function getTrackerRouter(redis: Redis, datastore: Datastore): Router {
             break;
 
           case 48 * 60:
-            key = Keys.fetcherFullNumTracksH48;
+            key = Keys.fetcherFullProtoH48;
             break;
 
           default:

--- a/libs/common/src/lib/live-track.ts
+++ b/libs/common/src/lib/live-track.ts
@@ -9,18 +9,35 @@ const DEVICE_TYPE_NUM_BITS = 5;
 const MAX_NUM_DEVICES = 2 ** DEVICE_TYPE_NUM_BITS - 1;
 const DEVICE_TYPE_BITMASK = 2 ** DEVICE_TYPE_NUM_BITS - 1;
 
-// How long to retain live tracking positions.
-export const LIVE_TRACKER_RETENTION_SEC = 24 * 3600;
-export const LIVE_FLIGHT_MODE_RETENTION_SEC = 40 * 60;
-// How long to keep ufo positions
-export const LIVE_UFO_RETENTION_SEC = 1 * 3600;
+export enum LiveDataRetentionSec {
+  // Incremental updates
+  IncrementalShort = 5 * 60,
+  IncrementalLong = 20 * 60,
+  // Full updates
+  FullH12 = 12 * 3600,
+  FullH24 = 24 * 3600,
+  FullH48 = 48 * 3600,
+  Max = FullH48,
+  // UFO updates
+  Ufo = 3600,
+  // Export to partners (max H12)
+  ExportToPartners = 5 * 60,
+}
+
+// Minium track point intervals.
+export enum LiveDataIntervalSec {
+  Recent = 5,
+  H6ToH12 = 60,
+  H12ToH24 = 3 * 60,
+  AfterH24 = 6 * 60,
+}
+
+export const TRACKERS_MAX_FETCH_DURATION_SEC = 24 * 3600;
 
 // Age for a point to be considered old.
 export const LIVE_AGE_OLD_SEC = 6 * 3600;
 // Minimum interval for old points points.
 export const LIVE_OLD_INTERVAL_SEC = 3 * 60;
-// Minimum interval between points.
-export const LIVE_MINIMAL_INTERVAL_SEC = 5;
 
 // Refresh interval (how often one update is triggered)
 export const LIVE_REFRESH_SEC = 60;
@@ -30,9 +47,6 @@ export const LIVE_FETCH_TIMEOUT_SEC = LIVE_REFRESH_SEC - 20;
 // Break tracks if gap is more than.
 export const TRACK_GAP_MIN = 60;
 
-// Incremental updates.
-export const LONG_INCREMENTAL_UPDATE_SEC = 20 * 60;
-export const SHORT_INCREMENTAL_UPDATE_SEC = 5 * 60;
 // Export to partners.
 export const EXPORT_UPDATE_SEC = 5 * 60;
 

--- a/libs/common/src/lib/redis-keys.ts
+++ b/libs/common/src/lib/redis-keys.ts
@@ -52,15 +52,21 @@ export enum Keys {
 
   // # Live Tracks
 
-  // Full tracks.
-  fetcherFullProto = 'f:live:full:proto',
-  // Number of full tracks.
-  fetcherFullNumTracks = 'f:live:full:size',
+  // Full tracks
+  fetcherFullProtoH12 = 'f:live:full:proto:h12',
+  fetcherFullProtoH24 = 'f:live:full:proto',
+  fetcherFullProtoH48 = 'f:live:full:proto:48',
+  // Number of pilots in full live tracks
+  fetcherFullNumTracksH12 = 'f:live:full:size:h12',
+  fetcherFullNumTracksH24 = 'f:live:full:size',
+  fetcherFullNumTracksH48 = 'f:live:full:size:h48',
+
   // Incremental tracks.
   fetcherLongIncrementalProto = 'f:live:inc:long:proto',
   fetcherShortIncrementalProto = 'f:live:inc:short:proto',
-  // Number of incremental tracks.
-  fetcherLongIncrementalNumTracks = 'f:live:inc:size',
+  // Number of pilots in incremental tracks.
+  fetcherIncrementalNumTracksLong = 'f:live:inc:size',
+
   // Tracks exported to FlyMe.
   fetcherExportFlymeProto = 'f:live:export:flyme',
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds support for retrieving 48 hours of live data history, refactors live data retention and interval constants into enums, and updates the logic for handling live track data to support multiple retention periods. Additionally, the privacy policy has been updated to reflect the new data retention period.

- **New Features**:
    - Introduced an option to retrieve 48 hours of live data history.
- **Enhancements**:
    - Refactored live data retention and interval constants into enums for better readability and maintainability.
    - Updated the logic for handling live track data to support multiple retention periods (12h, 24h, 48h).
    - Improved the process of adding and simplifying live tracks by introducing the `maybePushTrack` function.
- **Documentation**:
    - Updated the privacy policy to reflect the new 48-hour data retention period.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added option for displaying live track positions for up to 48 hours.
  - Updated Supporter Modal information to reflect current hosting costs.

- **Bug Fixes**
  - Enhanced error handling and logging across various modules.

- **Refactor**
  - Replaced old interval and retention constants with unified `LiveDataIntervalSec` and `LiveDataRetentionSec` enums.
  - Restructured data processing and track handling logic for better performance.
  - Refactored `getTrackerRouter` function to handle token-based requests more efficiently.

- **Documentation**
  - Updated privacy policy to reflect changes in live track position display duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->