### PR TITLE
Windy plugin

### DIFF
--- a/libs/secrets/package.json
+++ b/libs/secrets/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@nx/webpack": "19.4.2",
+    "@nx/webpack": "19.5.1",
     "dotenv-webpack": "^8.1.0"
   }
 }

--- a/libs/windy-sounding/CHANGELOG.md
+++ b/libs/windy-sounding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release history
 
-## 4.1.3
+## 4.1.3 - July 22, 2024
 
 - Fix center map when a favorite is selected on mobile
 

--- a/libs/windy-sounding/CHANGELOG.md
+++ b/libs/windy-sounding/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release history
 
+## 4.1.3
+
+- Fix center map when a favorite is selected on mobile
+
 ## 4.1.2 - Jul 19, 2024
 
 - Prevent an infinite loop when height === 0

--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -15,7 +15,7 @@
         "geojson": "^0.5.0",
         "preact": "^10.22.1",
         "react-redux": "^9.1.2",
-        "semver": "^7.6.2",
+        "semver": "^7.6.3",
         "svelte": "^4.2.18"
       },
       "devDependencies": {

--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-fxc-soundings",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.6",

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -18,7 +18,7 @@
     "geojson": "^0.5.0",
     "preact": "^10.22.1",
     "react-redux": "^9.1.2",
-    "semver": "^7.6.2",
+    "semver": "^7.6.3",
     "svelte": "^4.2.18"
   },
   "devDependencies": {

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/favorites.tsx
+++ b/libs/windy-sounding/src/components/favorites.tsx
@@ -2,9 +2,8 @@ import type { Fav, LatLon } from '@windy/interfaces';
 import { useState } from 'preact/hooks';
 
 import { round } from '../util/math';
-import { getFavLabel, SUPPORTED_MODEL_PREFIXES } from '../util/utils';
+import { getFavLabel, latLon2Str, SUPPORTED_MODEL_PREFIXES } from '../util/utils';
 
-const windyUtils = W.utils;
 const windyModels = W.models;
 
 export type FavoriteProps = {
@@ -16,7 +15,7 @@ export type FavoriteProps = {
 };
 
 export function Favorites({ favorites, location, isMobile, onSelected, modelName }: FavoriteProps) {
-  const locationStr = windyUtils.latLon2str(location);
+  const locationStr = latLon2Str(location);
   const [isModelExpanded, setIsModelExpanded] = useState(false);
   const [isLocationExpanded, setIsLocationExpanded] = useState(false);
 
@@ -48,7 +47,7 @@ export function Favorites({ favorites, location, isMobile, onSelected, modelName
       lon >= 0 ? 'E' : 'W'
     }`;
     for (const favorite of favorites) {
-      const favLocationStr = windyUtils.latLon2str(favorite);
+      const favLocationStr = latLon2Str(favorite);
       if (favLocationStr === locationStr) {
         currentFavorite = getFavLabel(favorite);
         break;
@@ -96,7 +95,7 @@ export function Favorites({ favorites, location, isMobile, onSelected, modelName
             ) : (
               favorites.map((favorite: Fav) => (
                 <span
-                  className={windyUtils.latLon2str(favorite) == locationStr ? 'selected' : ''}
+                  className={latLon2Str(favorite) == locationStr ? 'selected' : ''}
                   onClick={() => onSelected({ lat: favorite.lat, lon: favorite.lon })}
                 >
                   {getFavLabel(favorite)}
@@ -123,9 +122,7 @@ export function Favorites({ favorites, location, isMobile, onSelected, modelName
         return (
           <>
             <div
-              className={`button button--transparent ${
-                windyUtils.latLon2str(favorite) == locationStr ? 'selected' : ''
-              }`}
+              className={`button button--transparent ${latLon2Str(favorite) == locationStr ? 'selected' : ''}`}
               onClick={() => onSelected({ lat: favorite.lat, lon: favorite.lon })}
             >
               {getFavLabel(favorite)}

--- a/libs/windy-sounding/src/redux/forecast-slice.ts
+++ b/libs/windy-sounding/src/redux/forecast-slice.ts
@@ -14,6 +14,7 @@ import {
 } from '../util/clouds';
 import type { Scale } from '../util/math';
 import { sampleAt, scaleLinear } from '../util/math';
+import { latLon2Str } from '../util/utils';
 import * as pluginSlice from './plugin-slice';
 import type { AppThunkAPI, RootState } from './store';
 
@@ -200,7 +201,7 @@ export const fetchForecast = createAsyncThunk<Forecast, ModelAndLocation, { stat
 );
 
 function windyDataKey(modelName: string, location: LatLon): string {
-  return `${modelName}-${windyUtils.latLon2str(location)}`;
+  return `${modelName}-${latLon2Str(location)}`;
 }
 
 /**

--- a/libs/windy-sounding/src/redux/meta.ts
+++ b/libs/windy-sounding/src/redux/meta.ts
@@ -117,7 +117,7 @@ export function maybeRemoveMarker() {
  */
 export function centerMap(location: LatLon) {
   if (windyRootScope.isMobileOrTablet) {
-    const pluginContent = document.querySelector('#plugin-windy-plugin-sounding') as HTMLDivElement;
+    const pluginContent = document.querySelector(`#plugin-${pluginConfig.name}`) as HTMLDivElement;
     if (!pluginContent) {
       return;
     }

--- a/libs/windy-sounding/src/util/utils.ts
+++ b/libs/windy-sounding/src/util/utils.ts
@@ -32,3 +32,13 @@ export function formatTimestamp(ts: number) {
 export function getSupportedModelName(windyModelName: string): string {
   return SUPPORTED_MODEL_PREFIXES.some((prefix) => windyModelName.startsWith(prefix)) ? windyModelName : DEFAULT_MODEL;
 }
+
+/**
+ * Returns a code from a location (lat, lon).
+ *
+ * There is a bug in windy when lat or lon are strings (infinite loop).
+ * And sometimes favorites location are strings.
+ */
+export function latLon2Str({ lat, lon }: { lat: string | number; lon: string | number }): string {
+  return W.utils.latLon2str({ lat: Number(lat), lon: Number(lon) });
+}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug fix for centering the map when a favorite is selected on mobile and enhances the code by replacing `windyUtils.latLon2str` with a new `latLon2Str` function to handle string inputs for latitude and longitude.

- **Bug Fixes**:
    - Fixed a bug where selecting a favorite on mobile did not center the map.
- **Enhancements**:
    - Replaced usage of `windyUtils.latLon2str` with a new `latLon2Str` function to handle cases where latitude or longitude are strings, preventing potential infinite loops.
- **Chores**:
    - Updated the CHANGELOG.md to include the new version 4.1.3 release notes.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for converting latitude and longitude into string format, improving data handling.
	
- **Bug Fixes**
	- Updated the center map feature for improved functionality on mobile devices.

- **Chores**
	- Updated package dependencies to enhance performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->