### PR TITLE
Hide side pane when map is clicked on mobile

### DIFF
--- a/apps/fxc-front/src/app/components/menu-element.ts
+++ b/apps/fxc-front/src/app/components/menu-element.ts
@@ -18,10 +18,11 @@ export class MenuElement extends LitElement {
     this.eventController = new AbortController();
     this.addEventListener(
       'click',
-      async () => {
+      async (event: Event) => {
         if (this.splitPane) {
           this.splitPane.when = true;
         }
+        event.stopImmediatePropagation();
       },
       { signal: this.eventController.signal },
     );

--- a/apps/fxc-front/src/flyxc.ts
+++ b/apps/fxc-front/src/flyxc.ts
@@ -252,7 +252,7 @@ export class MapsElement extends connect(store)(LitElement) {
 
     return html` <ion-split-pane content-id="main" when=${SHOW_SPLIT_PANE_WHEN}>
         <main-menu></main-menu>
-        <ion-content id="main">
+        <ion-content id="main" @click=${this.contentClicked}>
           <ion-router-outlet class=${clMap}></ion-router-outlet>
           ${when(
             this.hasTrack,
@@ -266,6 +266,10 @@ export class MapsElement extends connect(store)(LitElement) {
         </ion-content>
       </ion-split-pane>
       <loader-element .show=${this.showLoader}></loader-element>`;
+  }
+
+  private contentClicked() {
+    maybeHideSidePane();
   }
 
   // Returns the coordinates of the active track at the given timestamp.


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Hide the side pane when the map is clicked on mobile devices by adding a click event handler to the main content. Enhance the menu element by stopping the propagation of click events to prevent interference with other components.

New Features:
- Implement functionality to hide the side pane when the map is clicked on mobile devices.

Enhancements:
- Add an event listener to the menu element to stop the propagation of click events, preventing unintended side effects.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced click event handling for the menu component, improving event management and user interaction tracking.
	- Introduced a new click event handler for the main content area, dynamically affecting the visibility of the side pane.

- **Bug Fixes**
	- Improved robustness of event handling to prevent unintended triggers of other event listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->