### PR TITLE
Virtual branch

### DIFF
--- a/apps/fetcher/Dockerfile
+++ b/apps/fetcher/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/_/node
 FROM docker.io/node:current-slim
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 ARG DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update -y \

--- a/apps/fetcher/project.json
+++ b/apps/fetcher/project.json
@@ -66,6 +66,7 @@
       "executor": "@nx-tools/nx-container:build",
       "dependsOn": ["build"],
       "options": {
+        "platforms": ["linux/amd64", "linux/arm64"],
         "engine": "docker",
         "push": true,
         "pull": true,

--- a/apps/fxc-tiles/Dockerfile
+++ b/apps/fxc-tiles/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/node:lts-slim
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 WORKDIR /usr/src/app
 RUN npm install -g npm@latest

--- a/apps/fxc-tiles/project.json
+++ b/apps/fxc-tiles/project.json
@@ -92,6 +92,7 @@
       "executor": "@nx-tools/nx-container:build",
       "dependsOn": ["build"],
       "options": {
+        "platforms": ["linux/amd64", "linux/arm64"],
         "engine": "docker",
         "pull": true,
         "push": true,

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/node:current-slim
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 ARG DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update -y \

--- a/apps/proxy/project.json
+++ b/apps/proxy/project.json
@@ -60,6 +60,7 @@
       "executor": "@nx-tools/nx-container:build",
       "dependsOn": ["build"],
       "options": {
+        "platforms": ["linux/amd64", "linux/arm64"],
         "engine": "docker",
         "push": true,
         "pull": true,

--- a/apps/run/Dockerfile
+++ b/apps/run/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/node:current-slim
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 ARG DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update -y \

--- a/apps/run/project.json
+++ b/apps/run/project.json
@@ -73,6 +73,7 @@
       "executor": "@nx-tools/nx-container:build",
       "dependsOn": ["build"],
       "options": {
+        "platforms": ["linux/amd64", "linux/arm64"],
         "engine": "docker",
         "push": true,
         "pull": true,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enable multi-platform Docker image builds for the fetcher, fxc-tiles, proxy, and run applications by adding 'linux/amd64' and 'linux/arm64' to the platforms option in their respective build configurations.

Build:
- Add support for building Docker images for multiple platforms, specifically 'linux/amd64' and 'linux/arm64', in the build configurations of the fetcher, fxc-tiles, proxy, and run applications.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for multiple build platforms (linux/amd64 and linux/arm64) across various applications.
- **Bug Fixes**
	- Clarified the syntax for setting environment variables in Dockerfiles, ensuring consistency across applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->