### PR TITLE
Use the node LTS release

### DIFF
--- a/apps/fetcher/Dockerfile
+++ b/apps/fetcher/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official lightweight Node.js image.
 # https://hub.docker.com/_/node
-FROM docker.io/node:current-slim
+FROM docker.io/node:lts-slim
 
 ENV NODE_ENV=production
 

--- a/apps/fxc-server/src/app.yaml
+++ b/apps/fxc-server/src/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs22
+runtime: nodejs20
 
 instance_class: F1
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:current-slim
+FROM docker.io/node:lts-slim
 
 ENV NODE_ENV=production
 

--- a/apps/run/Dockerfile
+++ b/apps/run/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:current-slim
+FROM docker.io/node:lts-slim
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
node v22 has been quite unstable. Switch back to node 20 until Oct24

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Change the Node.js runtime version from 22 to 20 in the app configuration to address stability issues.

Deployment:
- Switch the runtime environment from Node.js version 22 to Node.js version 20 in the app configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned to Long Term Support (LTS) version of Node.js for improved stability across multiple applications.
  
- **Bug Fixes**
	- Downgraded Node.js version in the configuration for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->