### PR TITLE
Meshtastic in all UI is renamed to bircom

### DIFF
--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -271,7 +271,7 @@ export class SettingsPage extends LitElement {
                   .binder=${this.binder}
                   label="UUID"
                   .hint=${html`<ion-text class="ion-padding-horizontal ion-padding-top block">
-                    Enter your Meshtastic UUID. It should look like "12345678-ab45-b23c-8549-1f3456c89e12".
+                    Enter your Bircom ID. It should look like "12345678-ab45-b23c-8549-1f3456c89e12".
                   </ion-text>`}
                 >
                 </device-card>
@@ -500,7 +500,7 @@ export class SettingsPage extends LitElement {
             <a href="https://www.glidernet.org/" target="_blank">OGN (Open Glider Network)</a>
           </li>
           <li><a href="https://live.xcontest.org/" target="_blank">XCTrack (XContest live)</a></li>
-          <li><a href="https://bircom.in/" target="_blank">Meshtastic (Bircom)</a></li>
+          <li><a href="https://bircom.in/" target="_blank">Bircom</a></li>
         </ul>
         <p>
           <a href="mailto:help@flyxc.app?subject=flyXC%20registration%20error" target="_blank"> Contact us by email </a>

--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -500,7 +500,7 @@ export class SettingsPage extends LitElement {
             <a href="https://www.glidernet.org/" target="_blank">OGN (Open Glider Network)</a>
           </li>
           <li><a href="https://live.xcontest.org/" target="_blank">XCTrack (XContest live)</a></li>
-          <li><a href="https://bircom.in/" target="_blank">Bircom</a></li>
+          <li><a href="https://bircom.in/" target="_blank">Bircom (Meshtastic)</a></li>
         </ul>
         <p>
           <a href="mailto:help@flyxc.app?subject=flyXC%20registration%20error" target="_blank"> Contact us by email </a>

--- a/libs/common/src/lib/live-track.ts
+++ b/libs/common/src/lib/live-track.ts
@@ -79,7 +79,7 @@ export const trackerDisplayNames: Readonly<Record<TrackerNames, string>> = {
   ogn: 'OGN',
   zoleo: 'zoleo',
   xcontest: 'XContest',
-  meshbir: 'Meshtastic',
+  meshbir: 'Bircom',
 };
 
 export const trackerIdByName: Record<TrackerNames, number> = {} as any;

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -134,7 +134,7 @@ export const trackerValidators: Readonly<Record<TrackerNames, AccountSyncValidat
   ogn: [new AccountSyncValidator('This OGN ID is invalid', validateOgnAccount)],
   zoleo: [],
   xcontest: [new AccountSyncValidator('This XContest UUID is invalid', validateXContestAccount)],
-  meshbir: [new AccountSyncValidator('This Meshtastic ID is invalid', validateMeshBirAccount)],
+  meshbir: [new AccountSyncValidator('This Bircom ID is invalid', validateMeshBirAccount)],
 };
 
 // Validates a Spot Id.

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -134,7 +134,7 @@ export const trackerValidators: Readonly<Record<TrackerNames, AccountSyncValidat
   ogn: [new AccountSyncValidator('This OGN ID is invalid', validateOgnAccount)],
   zoleo: [],
   xcontest: [new AccountSyncValidator('This XContest UUID is invalid', validateXContestAccount)],
-  meshbir: [new AccountSyncValidator('This Bircom ID is invalid', validateBircomAccount)],
+  meshbir: [new AccountSyncValidator('This Bircom ID is invalid', validateMeshBirAccount)],
 };
 
 // Validates a Spot Id.
@@ -227,7 +227,7 @@ export function validateXContestAccount(id: string): string | false {
 }
 
 // Validates a Meshtastic ID.
-export function validateBircomAccount(id: string): string | false {
+export function validateMeshBirAccount(id: string): string | false {
   id = id.trim();
   return /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i.test(id) ? id.toUpperCase() : false;
 }

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -134,7 +134,7 @@ export const trackerValidators: Readonly<Record<TrackerNames, AccountSyncValidat
   ogn: [new AccountSyncValidator('This OGN ID is invalid', validateOgnAccount)],
   zoleo: [],
   xcontest: [new AccountSyncValidator('This XContest UUID is invalid', validateXContestAccount)],
-  meshbir: [new AccountSyncValidator('This Bircom ID is invalid', validateMeshBirAccount)],
+  meshbir: [new AccountSyncValidator('This Bircom ID is invalid', validateBircomAccount)],
 };
 
 // Validates a Spot Id.
@@ -227,7 +227,7 @@ export function validateXContestAccount(id: string): string | false {
 }
 
 // Validates a Meshtastic ID.
-export function validateMeshBirAccount(id: string): string | false {
+export function validateBircomAccount(id: string): string | false {
   id = id.trim();
   return /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i.test(id) ? id.toUpperCase() : false;
 }


### PR DESCRIPTION
Meshtastic is a separate project, and this may likely cause confusion in the minds of users.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Rename 'Meshtastic' to 'Bircom' across the user interface to align with branding and avoid user confusion.

Enhancements:
- Rename all instances of 'Meshtastic' to 'Bircom' in the user interface to prevent confusion with the separate Meshtastic project.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated user interface text to reflect branding changes from "Meshtastic" to "Bircom."
	- Revised validation messages for user input to align with the new terminology.

- **Bug Fixes**
	- Clarified user prompts and messages to enhance user understanding and experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->