### PR TITLE
Fix Bircom route never returning a 200 status

### DIFF
--- a/apps/fxc-server/src/app/routes/meshbir.ts
+++ b/apps/fxc-server/src/app/routes/meshbir.ts
@@ -31,7 +31,7 @@ export function getMeshBirRouter(redis: Redis): Router {
       const pipeline = redis.pipeline();
       pushListCap(pipeline, Keys.meshBirMsgQueue, [JSON.stringify(message)], MESHBIR_MAX_MSG, MESHBIR_MAX_MSG_SIZE);
       await pipeline.exec();
-      return res.status(200);
+      return res.sendStatus(200);
     } catch (e) {
       console.error(e);
       return res.sendStatus(500);

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2.2.0",
   "license": "MIT",
   "scripts": {
-    "dev": "nx run-many --target=serve --projects=fxc-front,fxc-server,airspaces --configuration=development",
-    "check": "npm run fixlint && nx format && nx run-many --targets=test,lint,build --parallel 8",
-    "fixlint": "nx run-many -t lint --fix --parallel 8"
+    "dev": "nx build secrets && nx run-many --target=serve --projects=fxc-front,fxc-server,airspaces --configuration=development",
+    "check": "npm run fixlint && nx format && nx run-many --targets=test,lint,build --parallel 6",
+    "fixlint": "nx run-many -t lint --fix --parallel 6"
   },
   "nx": {
     "includedScripts": [


### PR DESCRIPTION
And minor tweaks

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the Bircom route to ensure it returns a 200 status code by using the correct method.

Bug Fixes:
- Fix the Bircom route to correctly return a 200 status code by using res.sendStatus(200) instead of res.status(200).

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced response handling for successful requests, improving clarity and efficiency.
  
- **Chores**
	- Updated development scripts to streamline the build process and adjust resource allocation during linting and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->