### PR TITLE
Fix Bircom messages

### DIFF
--- a/apps/fetcher/src/app/trackers/meshbir.test.ts
+++ b/apps/fetcher/src/app/trackers/meshbir.test.ts
@@ -286,12 +286,12 @@ describe('parse', () => {
     });
 
     it('associates message with the last known position when recent', () => {
-      jest.useFakeTimers({ now: 123500 });
+      jest.useFakeTimers({ now: 234500 });
       expect(
         parse(
           [
             {
-              time: 123440,
+              time: 234440,
               type: 'message',
               user_id: '12345678-1234-1234-1234-123456789012',
               message: 'message',
@@ -302,10 +302,10 @@ describe('parse', () => {
           {
             '10': protos.Pilot.create({
               track: protos.LiveTrack.create({
-                alt: [1],
-                lat: [2],
-                lon: [3],
-                timeSec: [123],
+                alt: [10, 11],
+                lat: [20, 21],
+                lon: [30, 31],
+                timeSec: [123, 234],
               }),
             }),
           },
@@ -315,12 +315,12 @@ describe('parse', () => {
         Map {
           "12345678-1234-1234-1234-123456789012" => [
             {
-              "alt": 1,
-              "lat": 2,
-              "lon": 3,
+              "alt": 11,
+              "lat": 21,
+              "lon": 31,
               "message": "message",
               "name": "meshbir",
-              "timeMs": 123500,
+              "timeMs": 234500,
             },
           ],
         }

--- a/apps/fetcher/src/app/trackers/meshbir.ts
+++ b/apps/fetcher/src/app/trackers/meshbir.ts
@@ -126,7 +126,7 @@ export function parse(
         continue;
       }
       const nowMs = Date.now();
-      const lastFixAgeSec = Math.round(nowMs / 1000) - track.timeSec[0];
+      const lastFixAgeSec = Math.round(nowMs / 1000) - track.timeSec.at(-1);
       if (lastFixAgeSec > messageAffinityMin * 60) {
         continue;
       }


### PR DESCRIPTION
Correctly look for the last known position

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the message association logic to correctly use the last known position by referencing the most recent timestamp in the track data, and update the corresponding test cases to validate this behavior.

Bug Fixes:
- Correct the logic to associate messages with the last known position by using the most recent timestamp in the track data.

Tests:
- Update test cases to reflect the changes in message association logic by adjusting timestamps and expected results.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the parsing logic to accurately reflect the most recent event's timestamp, improving the reliability of time-based data processing.
  
- **Tests**
	- Updated test cases to accommodate new data structures and ensure comprehensive coverage of parsing scenarios with multiple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->