### PR TITLE
Renaming Bircom to Paratracker, and LoRa mesh based instead of Meshtastic

### DIFF
--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -271,7 +271,7 @@ export class SettingsPage extends LitElement {
                   .binder=${this.binder}
                   label="UUID"
                   .hint=${html`<ion-text class="ion-padding-horizontal ion-padding-top block">
-                    Enter your Bircom ID. It should look like "12345678-ab45-b23c-8549-1f3456c89e12". Jigish Gohil
+                    Enter your Paratracker ID. It should look like "12345678-ab45-b23c-8549-1f3456c89e12". Jigish Gohil
                     explains the setup in
                     <a href="https://youtu.be/NuzwphHiXkI?si=6MW1hl8fodEnOTgd" target="_blank">this video</a>.
                   </ion-text>`}
@@ -502,7 +502,7 @@ export class SettingsPage extends LitElement {
             <a href="https://www.glidernet.org/" target="_blank">OGN (Open Glider Network)</a>
           </li>
           <li><a href="https://live.xcontest.org/" target="_blank">XCTrack (XContest live)</a></li>
-          <li><a href="https://bircom.in/" target="_blank">Bircom (Meshtastic)</a></li>
+          <li><a href="https://paratracker.in/" target="_blank">Paratracker (LoRa mesh based)</a></li>
         </ul>
         <p>
           <a href="mailto:help@flyxc.app?subject=flyXC%20registration%20error" target="_blank"> Contact us by email </a>

--- a/libs/common/src/lib/live-track.ts
+++ b/libs/common/src/lib/live-track.ts
@@ -79,7 +79,7 @@ export const trackerDisplayNames: Readonly<Record<TrackerNames, string>> = {
   ogn: 'OGN',
   zoleo: 'zoleo',
   xcontest: 'XContest',
-  meshbir: 'Bircom',
+  meshbir: 'Paratracker',
 };
 
 export const trackerIdByName: Record<TrackerNames, number> = {} as any;


### PR DESCRIPTION
Renaming Bircom to Paratracker as Bircom gives misleading idea that it is only for Bir area. It is intended to work anywhere that has one node in the mesh connected to the internet. Changing Meshtastic to LoRa mesh as in future we may also add support for FANET/OGN devices via our network, same hardware can used for those also with different firmware.

Will make new video after UI changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Rename Bircom to Paratracker and transition from Meshtastic to LoRa mesh to broaden the scope of the application and prepare for future device support.

Enhancements:
- Rename Bircom to Paratracker to better reflect its intended use beyond the Bir area.
- Switch from Meshtastic to LoRa mesh to allow future support for FANET/OGN devices using the same hardware with different firmware.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user interface text for improved clarity, changing "Bircom ID" to "Paratracker ID."
	- Updated links in the settings page to direct users to the new Paratracker website.

- **Bug Fixes**
	- Corrected tracker display names from "Bircom" to "Paratracker" for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->