### PR TITLE
Fix build

### DIFF
--- a/libs/windy-sounding/src/util/settings.ts
+++ b/libs/windy-sounding/src/util/settings.ts
@@ -5,7 +5,7 @@ export const Settings = {
   model: 2,
 } as const;
 
-type SettingKey = keyof typeof Settings;
+type SettingKey = (typeof Settings)[keyof typeof Settings];
 
 export function loadSetting(key: SettingKey): string | undefined {
   const value = localStorage.getItem(`${PLUGIN_NAMESPACE}${key}`);


### PR DESCRIPTION
## Summary by Sourcery

Fix the type definition for SettingKey in the settings utility to ensure it correctly references the values of the Settings object.

Bug Fixes:
- Correct the type definition for SettingKey to properly reference the values of the Settings object.