### PR TITLE
Check idle inReach less often

### DIFF
--- a/apps/fetcher/src/app/trackers/inreach.ts
+++ b/apps/fetcher/src/app/trackers/inreach.ts
@@ -155,10 +155,10 @@ export class InreachFetcher extends TrackerFetcher {
     }
     const lastFixAgeSec = Math.round(Date.now() / 1000) - tracker.lastFixSec;
     if (lastFixAgeSec > 6 * 30 * 24 * 3600) {
-      return Math.floor(45 + Math.random() * 3) * 60;
+      return Math.floor(55 + Math.random() * 10) * 60;
     }
     if (lastFixAgeSec > 3 * 30 * 24 * 3600) {
-      return Math.floor(30 + Math.random() * 3) * 60;
+      return Math.floor(35 + Math.random() * 5) * 60;
     }
     if (lastFixAgeSec > 3 * 3600) {
       return Math.floor(20 + Math.random() * 3) * 60;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust the frequency of checking idle inReach devices by increasing the intervals for devices with older last fix timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data fetching logic to adjust wait times based on the age of the last fix, potentially improving data retrieval efficiency.

- **Bug Fixes**
	- Updated conditions for fetching intervals to ensure more accurate timing based on the last fix age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->