### PR TITLE
Add OACI maps for France

### DIFF
--- a/apps/fxc-front/src/app/components/2d/map-element.ts
+++ b/apps/fxc-front/src/app/components/2d/map-element.ts
@@ -167,6 +167,7 @@ export class MapElement extends connect(store)(LitElement) {
             TopoOtm.mapTypeId,
             TopoFrance.mapTypeId,
             TopoFrance.mapTypeIdScan,
+            TopoFrance.mapTypeIdScanOACI,
             TopoSpain.mapTypeId,
           ],
           style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,

--- a/apps/fxc-front/src/app/components/2d/topo-elements.ts
+++ b/apps/fxc-front/src/app/components/2d/topo-elements.ts
@@ -18,11 +18,14 @@ export class TopoSpain extends WMTSMapTypeElement {
 
 const IGNFR_PLAN = 'GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2';
 const IGNFR_SCAN = 'GEOGRAPHICALGRIDSYSTEMS.MAPS';
+const IGNFR_SCAN_OACI = 'GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-OACI';
 
 @customElement('topo-france')
 export class TopoFrance extends WMTSMapTypeElement {
   static mapTypeId = 'topo.france.classique';
   static mapTypeIdScan = 'topo.france.scan';
+  static mapTypeIdScanOACI = 'topo.france.scan-oaci';
+
   mapName = 'France';
   copyright = {
     html: `<img src="/static/img/topo.fr.png" />`,
@@ -65,25 +68,42 @@ export class TopoFrance extends WMTSMapTypeElement {
       minZoom: 6,
       maxZoom: 17,
       name: 'France (scan)',
-      alt: 'France (scan)',
+      alt: 'France',
+    });
+  }
+
+  protected getScanOACIMapType(): google.maps.ImageMapType {
+    return new google.maps.ImageMapType({
+      getTileUrl: (...args): string => this.getTileUrl(...args),
+      tileSize: new google.maps.Size(256, 256),
+      minZoom: 6,
+      maxZoom: 11,
+      name: 'OACI (France)',
+      alt: 'OACI ',
     });
   }
 
   protected init(map: google.maps.Map): void {
     super.init(map);
     this.registerMapType(TopoFrance.mapTypeIdScan, this.getScanMapType());
+    this.registerMapType(TopoFrance.mapTypeIdScanOACI, this.getScanOACIMapType());
   }
 
   protected visibilityHandler(mapTypeId: string): void {
     if (this.copyrightEl) {
-      if (mapTypeId === TopoFrance.mapTypeId) {
-        this.layerName = IGNFR_PLAN;
-        this.copyrightEl.hidden = false;
-      } else if (mapTypeId === TopoFrance.mapTypeIdScan) {
-        this.layerName = IGNFR_SCAN;
-        this.copyrightEl.hidden = false;
-      } else {
-        this.copyrightEl.hidden = true;
+      this.copyrightEl.hidden = false;
+      switch (mapTypeId) {
+        case TopoFrance.mapTypeIdScanOACI:
+          this.layerName = IGNFR_SCAN_OACI;
+          break;
+        case TopoFrance.mapTypeIdScan:
+          this.layerName = IGNFR_SCAN;
+          break;
+        case TopoFrance.mapTypeId:
+          this.layerName = IGNFR_PLAN;
+          break;
+        default:
+          this.copyrightEl.hidden = true;
       }
     }
     super.visibilityHandler(mapTypeId);


### PR DESCRIPTION
## Summary by Sourcery

Add support for OACI maps for France by introducing a new map type and updating the visibility handler to accommodate the new map type. Enhance the map element to include the new OACI map type in the map type control options.

New Features:
- Introduce OACI map type for France, allowing users to view OACI maps in the application.

Enhancements:
- Refactor visibility handler to use a switch statement for better readability and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new map type, OACI, enhancing map options for users.
	- Added functionality to log zoom level changes for better user awareness.
	- Enhanced path drawing with route encoding for improved navigation.

- **Improvements**
	- Refined map interaction and state management for a smoother user experience.
	- Improved visibility handling logic for better clarity in map type management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->