### PR TITLE
Wait for the tiles to be loaded to display the map

### DIFF
--- a/apps/fxc-front/tsconfig.json
+++ b/apps/fxc-front/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": false,
     "module": "ES2020",
-    "lib": ["ES2020", "DOM", "WebWorker"],
+    "lib": ["ES2022", "DOM", "WebWorker"],
     "moduleResolution": "Bundler",
     "strict": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Wait for the map tiles to load before setting the API loading state to false, improving the user experience by preventing the map from briefly appearing without tiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading state management for Google Maps
  - Enhanced event listener cleanup to prevent potential memory leaks

- **Performance**
  - Optimized map component initialization and resource management

- **New Features**
  - Updated TypeScript configuration to utilize ECMAScript 2022 features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->