### PR TITLE
vb-branch-1

### DIFF
--- a/libs/windy-sounding/CHANGELOG.md
+++ b/libs/windy-sounding/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release history
 
+## 4.1.9 - Feb 16, 2025
+
+- Lower max altitude when zoomed in to ~5200m
+
 ## 4.1.8 - Oct 4, 2024
 
 - Drop `@windy.com/devtools` (use a local copy of the types)

--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-fxc-soundings",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -290,7 +290,7 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
     const minModelPressure = forecastSlice.selMinModelPressure(state, modelName, location);
     const pressureToGhScale = forecastSlice.selPressureToGhScale(state, modelName, location, timeMs);
     const minPressure = isZoomedIn
-      ? Math.round(Math.max(pressureToGhScale.invert(6500 + (elevation * 2) / 5), minModelPressure))
+      ? Math.round(Math.max(pressureToGhScale.invert(5200 + (elevation * 2) / 5), minModelPressure))
       : minModelPressure;
     const maxPressure = Math.min(1000, Math.round(pressureToGhScale.invert((elevation * 4) / 5)));
 


### PR DESCRIPTION
## Summary by Sourcery

Lower the max altitude when zoomed in to approximately 5200 meters. Update the changelog and package version to reflect this change.

Enhancements:
- Lower max altitude when zoomed in to ~5200m

Documentation:
- Document the change in max altitude when zoomed in

Chores:
- Update package version to 4.1.9 and changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced zoom functionality in the wind-sounding display by lowering the maximum altitude to approximately 5200 meters for improved results.
- **Chores**
  - Updated the release version to 4.1.9 (Feb 16, 2025).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->