### PR TITLE
windy-plugin: sync API

### DIFF
--- a/libs/windy-sounding/src/sounding.tsx
+++ b/libs/windy-sounding/src/sounding.tsx
@@ -27,6 +27,7 @@ const { emitter: windyPicker } = W.picker;
 const windyRootScope = W.rootScope;
 const { singleclick } = W.singleclick;
 const favs = W.userFavs;
+const broadcast = W.broadcast;
 
 let appContainer: HTMLElement;
 let resizeObserver: ResizeObserver | undefined;
@@ -103,11 +104,11 @@ export const mountPlugin = (container: HTMLElement) => {
     addSubscription(() => windyPicker.off(pickerMovedEventId));
   }
 
-  const favsChangedEventId = favs.on('favsChanged', () => {
+  const favChangedEventId = broadcast.on('favChanged', () => {
     dispatch(pluginSlice.setFavorites(favs.getArray()));
   });
 
-  addSubscription(() => favs.off(favsChangedEventId));
+  addSubscription(() => broadcast.off(favChangedEventId));
 };
 
 // Called when the plugin is opened


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- The plugin now uses the `broadcast` API to listen for changes to favorites, instead of the `favs` API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of favorite updates for more consistent and seamless synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->