### PR TITLE
update windy upload URL

### DIFF
--- a/libs/windy-sounding/upload.sh
+++ b/libs/windy-sounding/upload.sh
@@ -26,4 +26,4 @@ tar cf /tmp/plugin.tar -C dist/libs/windy-sounding plugin.min.js plugin.min.js.m
 
 echo "# Publishing plugin..."
 
-curl -s --fail-with-body -XPOST 'https://api.windy.com/api/windy-plugins/v1.0/upload' -H "x-windy-api-key: ${WINDY_API_KEY}" -F "plugin_archive=@/tmp/plugin.tar"
+curl -s --fail-with-body -XPOST 'https://node.windy.com/plugins/v1.0/upload' -H "x-windy-api-key: ${WINDY_API_KEY}" -F "plugin_archive=@/tmp/plugin.tar"


### PR DESCRIPTION
See https://github.com/windycom/windy-plugin-template/pull/38

## Summary by Sourcery

Build:
- Update the upload URL in the Windy plugin upload script to use the new endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the endpoint used for uploading plugins to ensure submissions go to the new server address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->