### PR TITLE
fixes timed airspaces

### DIFF
--- a/libs/common/src/lib/airspaces.test.ts
+++ b/libs/common/src/lib/airspaces.test.ts
@@ -11,6 +11,7 @@ import {
   Class,
   getAirspaceTileUrl,
   toTypedAirspace,
+  Type,
 } from './airspaces';
 import { fetchResponse } from './fetch-timeout';
 
@@ -167,6 +168,36 @@ describe('Time dependent Airspace', () => {
         "type": 7,
       }
     `);
+    expect(airspaces.get('TMA CHAMBERY 2')).toMatchInlineSnapshot(`
+      {
+        "activity": 0,
+        "country": "FR",
+        "floorLabel": "5500ft MSL",
+        "floorM": 1676,
+        "floorRefGnd": false,
+        "icaoClass": 4,
+        "name": "TMA CHAMBERY 2",
+        "topLabel": "FL 95",
+        "topM": 2896,
+        "topRefGnd": false,
+        "type": 7,
+      }
+    `);
+    expect(airspaces.get('TMA CHAMBERY 3')).toMatchInlineSnapshot(`
+      {
+        "activity": 0,
+        "country": "FR",
+        "floorLabel": "FL 95",
+        "floorM": 2896,
+        "floorRefGnd": false,
+        "icaoClass": 4,
+        "name": "TMA CHAMBERY 3",
+        "topLabel": "FL 115",
+        "topM": 3505,
+        "topRefGnd": false,
+        "type": 7,
+      }
+    `);
     expect(airspaces.get('CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)')).toMatchInlineSnapshot(`
       {
         "activity": 0,
@@ -207,82 +238,82 @@ describe('Time dependent Airspace', () => {
     expect(applyTimeRule(ecrins, new TZDate('2024-11-01', 'Europe/Paris'))).toEqual(ecrins);
     expect(applyTimeRule(ecrins, new TZDate('2024-12-31', 'Europe/Paris'))).toEqual(ecrins);
 
-    expect(applyTimeRule(ecrins, new TZDate('2024-07-01', 'Europe/Paris'))).not.toEqual(ecrins);
-    expect(applyTimeRule(ecrins, new TZDate('2024-10-31', 'Europe/Paris'))).not.toEqual(ecrins);
+    expect(applyTimeRule(ecrins, new TZDate('2024-07-01', 'Europe/Paris')).type).toEqual(Type.Other);
+    expect(applyTimeRule(ecrins, new TZDate('2024-10-31', 'Europe/Paris')).type).toEqual(Type.Other);
   });
 
   test('TMA CLERMONT 2.1 (VOL LIBRE)', () => {
     const clermont21 = airspaces.get('TMA CLERMONT 2.1 (VOL LIBRE)')!;
 
-    expect(applyTimeRule(clermont21, new TZDate('2024-01-01', 'Europe/Paris'))).not.toEqual(clermont21);
-    expect(applyTimeRule(clermont21, new TZDate('2024-03-14', 'Europe/Paris'))).not.toEqual(clermont21);
-    expect(applyTimeRule(clermont21, new TZDate('2024-10-16', 'Europe/Paris'))).not.toEqual(clermont21);
-    expect(applyTimeRule(clermont21, new TZDate('2024-12-31', 'Europe/Paris'))).not.toEqual(clermont21);
+    expect(applyTimeRule(clermont21, new TZDate('2024-01-01', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont21, new TZDate('2024-03-14', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont21, new TZDate('2024-10-16', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont21, new TZDate('2024-12-31', 'Europe/Paris')).topM).toEqual(1680);
 
-    expect(applyTimeRule(clermont21, new TZDate('2024-03-15', 'Europe/Paris'))).toEqual(clermont21);
-    expect(applyTimeRule(clermont21, new TZDate('2024-10-15', 'Europe/Paris'))).toEqual(clermont21);
+    expect(applyTimeRule(clermont21, new TZDate('2024-03-15', 'Europe/Paris')).topM).toEqual(1981);
+    expect(applyTimeRule(clermont21, new TZDate('2024-10-15', 'Europe/Paris')).topM).toEqual(1981);
   });
 
   test('TMA CLERMONT 2.2 CHAMPEIX (VOL LIBRE)', () => {
     const clermont22 = airspaces.get('TMA CLERMONT 2.2 CHAMPEIX (VOL LIBRE)')!;
 
-    expect(applyTimeRule(clermont22, new TZDate('2024-01-01', 'Europe/Paris'))).not.toEqual(clermont22);
-    expect(applyTimeRule(clermont22, new TZDate('2024-03-14', 'Europe/Paris'))).not.toEqual(clermont22);
-    expect(applyTimeRule(clermont22, new TZDate('2024-10-16', 'Europe/Paris'))).not.toEqual(clermont22);
-    expect(applyTimeRule(clermont22, new TZDate('2024-12-31', 'Europe/Paris'))).not.toEqual(clermont22);
+    expect(applyTimeRule(clermont22, new TZDate('2024-01-01', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont22, new TZDate('2024-03-14', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont22, new TZDate('2024-10-16', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont22, new TZDate('2024-12-31', 'Europe/Paris')).topM).toEqual(1680);
 
-    expect(applyTimeRule(clermont22, new TZDate('2024-03-15', 'Europe/Paris'))).toEqual(clermont22);
-    expect(applyTimeRule(clermont22, new TZDate('2024-10-15', 'Europe/Paris'))).toEqual(clermont22);
+    expect(applyTimeRule(clermont22, new TZDate('2024-03-15', 'Europe/Paris')).topM).toEqual(1980);
+    expect(applyTimeRule(clermont22, new TZDate('2024-10-15', 'Europe/Paris')).topM).toEqual(1980);
   });
 
   test('TMA CLERMONT 2.3 ORCINES (VOL LIBRE)', () => {
     const clermont23 = airspaces.get('TMA CLERMONT 2.3 ORCINES (VOL LIBRE)')!;
 
-    expect(applyTimeRule(clermont23, new TZDate('2024-01-01', 'Europe/Paris'))).not.toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-03-14', 'Europe/Paris'))).not.toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-10-16', 'Europe/Paris'))).not.toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-12-31', 'Europe/Paris'))).not.toEqual(clermont23);
+    expect(applyTimeRule(clermont23, new TZDate('2024-01-01', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont23, new TZDate('2024-03-14', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont23, new TZDate('2024-10-16', 'Europe/Paris')).topM).toEqual(1680);
+    expect(applyTimeRule(clermont23, new TZDate('2024-12-31', 'Europe/Paris')).topM).toEqual(1680);
 
     // 2024-03-15 is a Friday
-    expect(applyTimeRule(clermont23, new TZDate('2024-03-15', 'Europe/Paris'))).not.toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-03-16', 'Europe/Paris'))).toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-03-17', 'Europe/Paris'))).toEqual(clermont23);
+    expect(applyTimeRule(clermont23, new TZDate('2024-03-15', 'Europe/Paris')).topM).toEqual(1980);
+    expect(applyTimeRule(clermont23, new TZDate('2024-03-16', 'Europe/Paris')).topM).toEqual(2591);
+    expect(applyTimeRule(clermont23, new TZDate('2024-03-17', 'Europe/Paris')).topM).toEqual(2591);
 
     // 2024-10-15 is a Tuesday
-    expect(applyTimeRule(clermont23, new TZDate('2024-10-15', 'Europe/Paris'))).not.toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-10-13', 'Europe/Paris'))).toEqual(clermont23);
-    expect(applyTimeRule(clermont23, new TZDate('2024-10-12', 'Europe/Paris'))).toEqual(clermont23);
+    expect(applyTimeRule(clermont23, new TZDate('2024-10-15', 'Europe/Paris')).topM).toEqual(1980);
+    expect(applyTimeRule(clermont23, new TZDate('2024-10-13', 'Europe/Paris')).topM).toEqual(2591);
+    expect(applyTimeRule(clermont23, new TZDate('2024-10-12', 'Europe/Paris')).topM).toEqual(2591);
   });
 
   test('TMA CLERMONT 4.1 JOB (VOL LIBRE)', () => {
     const clermont41 = airspaces.get('TMA CLERMONT 4.1 JOB (VOL LIBRE)')!;
 
-    expect(applyTimeRule(clermont41, new TZDate('2024-01-01', 'Europe/Paris'))).not.toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-03-14', 'Europe/Paris'))).not.toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-10-16', 'Europe/Paris'))).not.toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-12-31', 'Europe/Paris'))).not.toEqual(clermont41);
+    expect(applyTimeRule(clermont41, new TZDate('2024-01-01', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont41, new TZDate('2024-03-14', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont41, new TZDate('2024-10-16', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont41, new TZDate('2024-12-31', 'Europe/Paris')).topM).toEqual(2590);
 
     // 2024-03-15 is a Friday
-    expect(applyTimeRule(clermont41, new TZDate('2024-03-15', 'Europe/Paris'))).not.toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-03-16', 'Europe/Paris'))).toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-03-17', 'Europe/Paris'))).toEqual(clermont41);
+    expect(applyTimeRule(clermont41, new TZDate('2024-03-15', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont41, new TZDate('2024-03-16', 'Europe/Paris')).topM).toEqual(2896);
+    expect(applyTimeRule(clermont41, new TZDate('2024-03-17', 'Europe/Paris')).topM).toEqual(2896);
 
     // 2024-10-15 is a Tuesday
-    expect(applyTimeRule(clermont41, new TZDate('2024-10-15', 'Europe/Paris'))).not.toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-10-13', 'Europe/Paris'))).toEqual(clermont41);
-    expect(applyTimeRule(clermont41, new TZDate('2024-10-12', 'Europe/Paris'))).toEqual(clermont41);
+    expect(applyTimeRule(clermont41, new TZDate('2024-10-15', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont41, new TZDate('2024-10-13', 'Europe/Paris')).topM).toEqual(2896);
+    expect(applyTimeRule(clermont41, new TZDate('2024-10-12', 'Europe/Paris')).topM).toEqual(2896);
   });
 
   test('TMA CLERMONT5.1 PUY DE DOME (VOL LIBRE)', () => {
     const clermont51 = airspaces.get('TMA CLERMONT5.1 PUY DE DOME (VOL LIBRE)')!;
 
-    expect(applyTimeRule(clermont51, new TZDate('2024-01-01', 'Europe/Paris'))).not.toEqual(clermont51);
-    expect(applyTimeRule(clermont51, new TZDate('2024-03-14', 'Europe/Paris'))).not.toEqual(clermont51);
-    expect(applyTimeRule(clermont51, new TZDate('2024-10-16', 'Europe/Paris'))).not.toEqual(clermont51);
-    expect(applyTimeRule(clermont51, new TZDate('2024-12-31', 'Europe/Paris'))).not.toEqual(clermont51);
+    expect(applyTimeRule(clermont51, new TZDate('2024-01-01', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont51, new TZDate('2024-03-14', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont51, new TZDate('2024-10-16', 'Europe/Paris')).topM).toEqual(2590);
+    expect(applyTimeRule(clermont51, new TZDate('2024-12-31', 'Europe/Paris')).topM).toEqual(2590);
 
-    expect(applyTimeRule(clermont51, new TZDate('2024-03-15', 'Europe/Paris'))).toEqual(clermont51);
-    expect(applyTimeRule(clermont51, new TZDate('2024-10-15', 'Europe/Paris'))).toEqual(clermont51);
+    expect(applyTimeRule(clermont51, new TZDate('2024-03-15', 'Europe/Paris')).topM).toEqual(3505);
+    expect(applyTimeRule(clermont51, new TZDate('2024-10-15', 'Europe/Paris')).topM).toEqual(3505);
   });
 
   test('LF-R30B MONT BLANC (JULY+AUGUST)', () => {
@@ -297,53 +328,44 @@ describe('Time dependent Airspace', () => {
     expect(applyTimeRule(r30b, new TZDate('2024-08-31', 'Europe/Paris'))).toEqual(r30b);
   });
 
-  test('TMA CHAMBERY 1', () => {
-    const chamberyTMA1 = airspaces.get('TMA CHAMBERY 1')!;
-    // TODO: remove when openaip is fixed
-    chamberyTMA1.icaoClass = Class.D;
+  test('TMA CHAMBERY', () => {
+    for (const tmaName of ['TMA CHAMBERY 1', 'TMA CHAMBERY 2', 'TMA CHAMBERY 3']) {
+      const tma = airspaces.get(tmaName)!;
+      // openaip has class E
+      tma.icaoClass = Class.D;
 
-    // E from 2nd Monday of April to 2nd Friday of December
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-04-14', 'Europe/Paris'))).not.toEqual(chamberyTMA1);
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-12-12', 'Europe/Paris'))).not.toEqual(chamberyTMA1);
+      // E from 2nd Monday of April to 2nd Friday of December
+      expect(applyTimeRule(tma, new TZDate('2025-04-14', 'Europe/Paris'))).not.toEqual(tma);
+      expect(applyTimeRule(tma, new TZDate('2025-12-12', 'Europe/Paris'))).not.toEqual(tma);
 
-    // E from from Monday 11UTC to Thursday 23:59UTC
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-04-13', 'Europe/Paris'))).toEqual(chamberyTMA1);
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-12-13', 'Europe/Paris'))).toEqual(chamberyTMA1);
-    // Tuesday -> Thursday
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-04-08', 'Europe/Paris'))).not.toEqual(chamberyTMA1);
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-04-09', 'Europe/Paris'))).not.toEqual(chamberyTMA1);
-    expect(applyTimeRule(chamberyTMA1, new TZDate('2025-04-10', 'Europe/Paris'))).not.toEqual(chamberyTMA1);
+      // E from from Monday 11UTC to Thursday 23:59UTC
+      expect(applyTimeRule(tma, new TZDate('2025-04-13', 'Europe/Paris'))).toEqual(tma);
+      expect(applyTimeRule(tma, new TZDate('2025-12-13', 'Europe/Paris'))).toEqual(tma);
+      // Tuesday -> Thursday
+      expect(applyTimeRule(tma, new TZDate('2025-04-08', 'Europe/Paris'))).not.toEqual(tma);
+      expect(applyTimeRule(tma, new TZDate('2025-04-09', 'Europe/Paris'))).not.toEqual(tma);
+      expect(applyTimeRule(tma, new TZDate('2025-04-10', 'Europe/Paris'))).not.toEqual(tma);
+    }
   });
 
-  test('CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)', () => {
-    const chamberyCTR2 = airspaces.get('CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)')!;
+  test('CTR CHAMBERY', () => {
+    for (const ctrName of [
+      'CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)',
+      'CTR CHAMBERY 3 (ACTIVE MID DEC -> MID AVRIL)',
+    ]) {
+      const ctr = airspaces.get(ctrName)!;
 
-    // E from 2nd Monday of April to 2nd Friday of December
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-04-14', 'Europe/Paris'))).not.toEqual(chamberyCTR2);
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-12-12', 'Europe/Paris'))).not.toEqual(chamberyCTR2);
+      // E from 2nd Monday of April to 2nd Friday of December
+      expect(applyTimeRule(ctr, new TZDate('2025-04-14', 'Europe/Paris'))).not.toEqual(ctr);
+      expect(applyTimeRule(ctr, new TZDate('2025-12-12', 'Europe/Paris'))).not.toEqual(ctr);
 
-    // E from from Monday 11UTC to Thursday 23:59UTC
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-04-13', 'Europe/Paris'))).toEqual(chamberyCTR2);
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-12-13', 'Europe/Paris'))).toEqual(chamberyCTR2);
-    // Tuesday -> Thursday
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-04-08', 'Europe/Paris'))).not.toEqual(chamberyCTR2);
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-04-09', 'Europe/Paris'))).not.toEqual(chamberyCTR2);
-    expect(applyTimeRule(chamberyCTR2, new TZDate('2025-04-10', 'Europe/Paris'))).not.toEqual(chamberyCTR2);
-  });
-
-  test('CTR CHAMBERY 3 (ACTIVE MID DEC -> MID AVRIL)', () => {
-    const chamberyCTR3 = airspaces.get('CTR CHAMBERY 3 (ACTIVE MID DEC -> MID AVRIL)')!;
-
-    // E from 2nd Monday of April to 2nd Friday of December
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-04-14', 'Europe/Paris'))).not.toEqual(chamberyCTR3);
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-12-12', 'Europe/Paris'))).not.toEqual(chamberyCTR3);
-
-    // E from from Monday 11UTC to Thursday 23:59UTC
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-04-13', 'Europe/Paris'))).toEqual(chamberyCTR3);
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-12-13', 'Europe/Paris'))).toEqual(chamberyCTR3);
-    // Tuesday -> Thursday
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-04-08', 'Europe/Paris'))).not.toEqual(chamberyCTR3);
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-04-09', 'Europe/Paris'))).not.toEqual(chamberyCTR3);
-    expect(applyTimeRule(chamberyCTR3, new TZDate('2025-04-10', 'Europe/Paris'))).not.toEqual(chamberyCTR3);
+      // E from from Monday 11UTC to Thursday 23:59UTC
+      expect(applyTimeRule(ctr, new TZDate('2025-04-13', 'Europe/Paris'))).toEqual(ctr);
+      expect(applyTimeRule(ctr, new TZDate('2025-12-13', 'Europe/Paris'))).toEqual(ctr);
+      // Tuesday -> Thursday
+      expect(applyTimeRule(ctr, new TZDate('2025-04-08', 'Europe/Paris'))).not.toEqual(ctr);
+      expect(applyTimeRule(ctr, new TZDate('2025-04-09', 'Europe/Paris'))).not.toEqual(ctr);
+      expect(applyTimeRule(ctr, new TZDate('2025-04-10', 'Europe/Paris'))).not.toEqual(ctr);
+    }
   });
 });

--- a/libs/common/src/lib/airspaces.ts
+++ b/libs/common/src/lib/airspaces.ts
@@ -458,7 +458,7 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
       }
       return {
         ...airspace,
-        ...(isSaturday(tzDate) || isSunday(tzDate) ? undefined : { topM: 1980, topLabel: '1980m' }),
+        ...(isSaturday(tzDate) || isSunday(tzDate) ? {} : { topM: 1980, topLabel: '1980m' }),
       };
     }
 
@@ -472,7 +472,7 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
       }
       return {
         ...airspace,
-        ...(isSaturday(tzDate) || isSunday(tzDate) ? undefined : { topM: 2590, topLabel: '2590m' }),
+        ...(isSaturday(tzDate) || isSunday(tzDate) ? {} : { topM: 2590, topLabel: '2590m' }),
       };
     }
 

--- a/libs/common/src/lib/airspaces.ts
+++ b/libs/common/src/lib/airspaces.ts
@@ -398,6 +398,8 @@ export const timedAirspaces = [
   // - 2nd Monday of April to 2nd Friday of December
   // - outside the above period: Monday 11:00UTC to Thursday 23:59UTC
   'TMA CHAMBERY 1',
+  'TMA CHAMBERY 2',
+  'TMA CHAMBERY 3',
   'CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)',
   'CTR CHAMBERY 3 (ACTIVE MID DEC -> MID AVRIL)',
 ] as const;
@@ -430,7 +432,7 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
       const lower = isBefore(tzDate, start) || isAfter(tzDate, end);
       if (lower) {
-        return { ...airspace, topM: 1680 };
+        return { ...airspace, topM: 1680, topLabel: '1680m' };
       }
       return airspace;
     }
@@ -441,9 +443,9 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
       const lower = isBefore(tzDate, start) || isAfter(tzDate, end);
       if (lower) {
-        return { ...airspace, topM: 1680 };
+        return { ...airspace, topM: 1680, topLabel: '1680m' };
       }
-      return airspace;
+      return { ...airspace, topM: 1980, topLabel: '1980m' };
     }
 
     case 'TMA CLERMONT 2.3 ORCINES (VOL LIBRE)': {
@@ -452,11 +454,11 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
       const lower = isBefore(tzDate, start) || isAfter(tzDate, end);
       if (lower) {
-        return { ...airspace, topM: 1680 };
+        return { ...airspace, topM: 1680, topLabel: '1680m' };
       }
       return {
         ...airspace,
-        topM: isSaturday(tzDate) || isSunday(tzDate) ? 2591 : 1980,
+        ...(isSaturday(tzDate) || isSunday(tzDate) ? undefined : { topM: 1980, topLabel: '1980m' }),
       };
     }
 
@@ -466,11 +468,11 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
       const lower = isBefore(tzDate, start) || isAfter(tzDate, end);
       if (lower) {
-        return { ...airspace, topM: 2590 };
+        return { ...airspace, topM: 2590, topLabel: '2590m' };
       }
       return {
         ...airspace,
-        topM: isSaturday(tzDate) || isSunday(tzDate) ? 2896 : 2590,
+        ...(isSaturday(tzDate) || isSunday(tzDate) ? undefined : { topM: 2590, topLabel: '2590m' }),
       };
     }
 
@@ -480,7 +482,7 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
       const lower = isBefore(tzDate, start) || isAfter(tzDate, end);
       if (lower) {
-        return { ...airspace, topM: 2590 };
+        return { ...airspace, topM: 2590, topLabel: '2590m' };
       }
       return airspace;
     }
@@ -497,7 +499,28 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
 
     case 'TMA CHAMBERY 1':
     case 'TMA CHAMBERY 2':
-    case 'TMA CHAMBERY 3':
+    case 'TMA CHAMBERY 3': {
+      // 2nd Monday of April
+      const start = addDays(nextMonday(new TZDate(`${year}-04-01`, 'Europe/Paris')), 7);
+      // 2nd Friday of December
+      const end = addDays(nextFriday(new TZDate(`${year}-12-01`, 'Europe/Paris')), 7);
+
+      const isClassD =
+        (isBefore(tzDate, start) || isAfter(tzDate, end)) &&
+        (isFriday(tzDate) ||
+          isSaturday(tzDate) ||
+          isSunday(tzDate) ||
+          (isMonday(tzDate) && tzDate.getUTCHours() <= 11));
+
+      return isClassD
+        ? // openaip has class E
+          { ...airspace, icaoClass: Class.D }
+        : {
+            ...airspace,
+            icaoClass: Class.E,
+          };
+    }
+
     case 'CTR CHAMBERY 2 (ACTIVE MID DEC -> MID AVRIL)':
     case 'CTR CHAMBERY 3 (ACTIVE MID DEC -> MID AVRIL)': {
       // 2nd Monday of April
@@ -505,26 +528,22 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
       // 2nd Friday of December
       const end = addDays(nextFriday(new TZDate(`${year}-12-01`, 'Europe/Paris')), 7);
 
-      if (isBefore(tzDate, start) || isAfter(tzDate, end)) {
-        const isClassD =
-          isFriday(tzDate) ||
+      const isActive =
+        (isBefore(tzDate, start) || isAfter(tzDate, end)) &&
+        (isFriday(tzDate) ||
           isSaturday(tzDate) ||
           isSunday(tzDate) ||
-          (isMonday(tzDate) && tzDate.getUTCHours() <= 11);
-        return isClassD
-          ? // TODO: asked Stephan to change to D
-            { ...airspace, icaoClass: Class.D }
-          : {
-              ...airspace,
-              icaoClass: Class.E,
-              name: `${airspace.name} (E)`,
-            };
-      }
-      return {
-        ...airspace,
-        icaoClass: Class.E,
-        name: `${airspace.name} (E)`,
-      };
+          (isMonday(tzDate) && tzDate.getUTCHours() <= 11));
+
+      return isActive
+        ? // openaip has class E
+          { ...airspace, icaoClass: Class.D }
+        : {
+            ...airspace,
+            icaoClass: Class.SUA,
+            type: Type.Other,
+            name: `${airspace.name} - INACTIVE`,
+          };
     }
 
     default:


### PR DESCRIPTION
## Summary by Sourcery

Correct the application of time-dependent rules for several French airspaces, ensuring accurate activation status and altitude limits based on date and time.

Bug Fixes:
- Fix activation logic for Chambery TMAs (1, 2, 3) and CTRs (2, 3) according to their defined schedules.
- Properly designate inactive Chambery CTRs.
- Ensure altitude labels for Clermont TMAs reflect time-based ceiling changes.
- Include 'TMA CHAMBERY 2' and 'TMA CHAMBERY 3' in time-dependent processing logic (previously missed).

Tests:
- Improve test coverage and accuracy for time-dependent airspace logic, verifying specific properties.
- Add tests for 'TMA CHAMBERY 2' and 'TMA CHAMBERY 3'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for "TMA CHAMBERY 2" and "TMA CHAMBERY 3" airspaces with time-based classification and altitude labeling.
- **Improvements**
  - Enhanced rules for "TMA CHAMBERY" and "CTR CHAMBERY" airspaces, introducing more precise time and day-based classification and labeling.
  - Improved altitude labels and conditions for several "TMA CLERMONT" airspaces, especially for weekends.
- **Bug Fixes**
  - More accurate handling of airspace classification and labeling based on specific dates and times.
- **Refactor**
  - Streamlined and consolidated related tests for maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->