### PR TITLE
patch aiguillles rouges airspace

### DIFF
--- a/libs/common/src/lib/airspaces.test.ts
+++ b/libs/common/src/lib/airspaces.test.ts
@@ -228,6 +228,32 @@ describe('Time dependent Airspace', () => {
         "type": 4,
       }
     `);
+    expect(airspaces.get('PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL')).toMatchInlineSnapshot(`
+      {
+        "activity": 0,
+        "country": "FR",
+        "floorLabel": "GND",
+        "floorM": 0,
+        "floorRefGnd": true,
+        "icaoClass": 8,
+        "name": "PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL",
+        "topLabel": "3281ft GND",
+        "topM": 1000,
+        "topRefGnd": true,
+        "type": 29,
+      }
+    `);
+  });
+
+  test('PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL', () => {
+    const aiguillesRouges = airspaces.get('PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL')!;
+    const override = applyTimeRule(aiguillesRouges, new TZDate('2024-07-01', 'Europe/Paris'));
+
+    expect(override).toMatchObject({
+      topM: 300,
+      topLabel: '984ft GND',
+      name: 'PARC/RESERVE  AIGUILLES ROUGES 300M/SOL',
+    });
   });
 
   test('PARC/RESERVE  ECRINS 1000M/SOL', () => {

--- a/libs/common/src/lib/airspaces.ts
+++ b/libs/common/src/lib/airspaces.ts
@@ -394,6 +394,9 @@ export const timedAirspaces = [
   // Active in July and August
   // https://federation.ffvl.fr/sites/ffvl.fr/files/Massifdumontblancchamonix.pdf
   'LF-R30B MONT BLANC (JULY+AUGUST)',
+  // 300m AGL for PG
+  // https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000021755667
+  'PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL',
   // Class E
   // - 2nd Monday of April to 2nd Friday of December
   // - outside the above period: Monday 11:00UTC to Thursday 23:59UTC
@@ -416,6 +419,14 @@ export function applyTimeRule(airspace: AirspaceTyped, date: Date): AirspaceType
   const month = tzDate.getMonth() + 1;
 
   switch (airspace.name) {
+    case 'PARC/RESERVE  AIGUILLES ROUGES 1000M/SOL':
+      return {
+        ...airspace,
+        name: 'PARC/RESERVE  AIGUILLES ROUGES 300M/SOL',
+        topM: 300,
+        topLabel: '984ft GND',
+      };
+
     case 'PARC/RESERVE  ECRINS 1000M/SOL':
       if (month >= 7 && month <= 10) {
         return {


### PR DESCRIPTION
## Summary by Sourcery

Update airspace rules for Aiguilles Rouges national park to reflect seasonal height restrictions for paragliding

New Features:
- Add time-dependent airspace rule for Aiguilles Rouges national park

Tests:
- Add test case for Aiguilles Rouges airspace time-dependent height restriction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a specific altitude restriction for the "PARC/RESERVE  AIGUILLES ROUGES" airspace, applying a 300m AGL limit for paragliders effective July 1, 2024.
- **Tests**
  - Added tests to verify the updated altitude restriction and related airspace properties for the affected area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->