### PR TITLE
Add a name to GPX routes

### DIFF
--- a/apps/fxc-server/src/app/waypoints/waypoints.test.ts
+++ b/apps/fxc-server/src/app/waypoints/waypoints.test.ts
@@ -1,0 +1,40 @@
+import { encodeGPXRoute } from './waypoints';
+
+describe('waypoints', () => {
+  test('encodeGPXRoute', () => {
+    expect(
+      encodeGPXRoute(
+        [
+          { lat: 1.1, lon: 2.2, alt: 100 },
+          { lat: 3.3, lon: 4.4, alt: 200 },
+          { lat: 5.5, lon: 6.6, alt: 300 },
+        ],
+
+        'pre',
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "file": "<?xml version="1.0" encoding="UTF-8"?>
+      <gpx>
+        <data>
+          <rte>
+            <name>flyXC route</name>
+            <rtept lat="1.100000" lon="2.200000">
+              <name>pre001</name>
+            </rtept>
+            <rtept lat="3.300000" lon="4.400000">
+              <name>pre002</name>
+            </rtept>
+            <rtept lat="5.500000" lon="6.600000">
+              <name>pre003</name>
+            </rtept>
+          </rte>
+        </data>
+        <schemaLocation>http://www.topografix.com/GPX/1/1,https://www.topografix.com/GPX/1/1/gpx.xsd</schemaLocation>
+      </gpx>",
+        "filename": "route.gpx",
+        "mime": "application/gpx+xml",
+      }
+    `);
+  });
+});

--- a/apps/fxc-server/src/app/waypoints/waypoints.ts
+++ b/apps/fxc-server/src/app/waypoints/waypoints.ts
@@ -72,7 +72,7 @@ function encodeGPXWaypoints(
   return { file: buildGPX(gpxData), mime: 'application/gpx+xml', filename: 'waypoints.gpx' };
 }
 
-function encodeGPXRoute(
+export function encodeGPXRoute(
   points: LatLonAlt[],
   prefix: string,
 ): { mime?: string; file?: string; filename?: string; error?: string } {
@@ -89,7 +89,10 @@ function encodeGPXRoute(
   const route = new Route({ rtept });
   const gpxData = new BaseBuilder();
   gpxData.setRoutes([route]);
-  return { file: buildGPX(gpxData), mime: 'application/gpx+xml', filename: 'route.gpx' };
+  // Fix for https://github.com/vicb/flyXC/issues/362
+  // Passing a name to `new Route({name, ...})` would add the name as the last child
+  const file = buildGPX(gpxData).replace('<rte>', '<rte>\n      <name>flyXC route</name>');
+  return { file, mime: 'application/gpx+xml', filename: 'route.gpx' };
 }
 
 function encodeKML(


### PR DESCRIPTION
fixes #362

## Summary by Sourcery

Export and enhance GPX route encoding to include a default name element in the output and make the function accessible (fix #362).

Bug Fixes:
- Add <name> element to generated GPX routes to include a route name.

Enhancements:
- Export encodeGPXRoute function from waypoints module for external use.

Tests:
- Add tests for GPX route encoding to verify name injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the route name "flyXC route" to exported GPX files for improved clarity when viewing routes.
- **Tests**
  - Introduced new tests to verify correct formatting of GPX route exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->