### PR TITLE
Update OGN

### DIFF
--- a/apps/fetcher/src/app/trackers/ogn-client.ts
+++ b/apps/fetcher/src/app/trackers/ogn-client.ts
@@ -119,11 +119,9 @@ export class OgnClient {
             const positions = this.positions.get(id);
             if (positions == null) {
               this.positions.set(id, [position]);
-            } else {
+            } else if (position.timeSec >= positions.at(-1).timeSec + 5) {
               // Max 1 point every 5s
-              if (position.timeSec >= positions.at(-1).timeSec + 5) {
-                positions.push(position);
-              }
+              positions.push(position);
             }
           }
         }

--- a/apps/fetcher/src/app/trackers/ogn-client.ts
+++ b/apps/fetcher/src/app/trackers/ogn-client.ts
@@ -8,7 +8,9 @@ import type { AprsPosition } from '@flyxc/common';
 import { parseAprsPosition } from '@flyxc/common';
 
 const VERSION = '1.0';
-const OGN_FAST_ID_REGEXP = /\bid[0-9a-z]{2}(?<id>[0-9a-z]{6})\b/i;
+// ICA3C6742>OGADSB,qAS,AVX1100:/181728h5022.93N/00925.77E^223/318/A=011197 !W42! id253C6742 -1280fpm FL105.29 A3:DLH6AX Sq5662
+// NAVFE0B52>OGNAVI,qAS,NAVITER2:/181152h4332.89N/11619.14W'000/000/A=002726 !W69! id1C40FE0B52 +000fpm +0.0rot
+const OGN_FAST_ID_REGEXP = /\bid[0-9a-z]*?(?<id>[0-9a-z]{6})\b/i;
 const OGN_POSITION_REGEXP = /^(?<src>.+?)>.*?:\/(?<position>.*)$/i;
 const MAX_NUM_POSITIONS = 100000;
 const TX_KEEP_ALIVE_MIN = 10;
@@ -118,7 +120,10 @@ export class OgnClient {
             if (positions == null) {
               this.positions.set(id, [position]);
             } else {
-              positions.push(position);
+              // Max 1 point every 5s
+              if (position.timeSec >= positions.at(-1).timeSec + 5) {
+                positions.push(position);
+              }
             }
           }
         }

--- a/libs/common/src/lib/aprs.test.ts
+++ b/libs/common/src/lib/aprs.test.ts
@@ -116,7 +116,8 @@ describe('parseAprsPosition', () => {
     });
   });
 
-  it('parse comment', () => {
+  // Comments removed to save memory
+  it.skip('parse comment', () => {
     expect(parseAprsPosition('123456h0000.00N/00000.00E/')).toMatchObject({
       comment: undefined,
     });

--- a/libs/common/src/lib/aprs.ts
+++ b/libs/common/src/lib/aprs.ts
@@ -72,7 +72,6 @@ export function parseAprsPosition(position: string, nowSec = Math.round(Date.now
   const speed = Math.round(Number(match.groups['speed'] ?? '0') * KNOT_IN_KMH);
   const course = Number(match.groups['course'] ?? '0');
   const alt = Math.round(Number(match.groups['alt'] ?? '0') * FT_IN_METER);
-  const comment = match.groups['comment'];
   return {
     lat,
     lon,
@@ -80,7 +79,6 @@ export function parseAprsPosition(position: string, nowSec = Math.round(Date.now
     alt,
     speed,
     course,
-    comment,
   };
 }
 


### PR DESCRIPTION
Relax ID regex for SeeYou navigator
Save mem by not parsing comments and  keeping fix only when 5+s apart

## Summary by Sourcery

Relax OGN ID matching, throttle stored fixes to one per 5 seconds, and drop APRS comment parsing to reduce memory usage

Enhancements:
- Relax the OGN ID regex to accommodate SeeYou navigator IDs
- Only retain position fixes at least 5 seconds apart to save memory
- Remove parsing of APRS comments to reduce memory footprint

Tests:
- Skip the APRS comment parsing test after removing comment support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device ID extraction to support IDs with variable-length prefixes.
  * Added rate limiting to position updates, ensuring no more than one position is stored per device within a 5-second interval.

* **Tests**
  * Disabled a test related to APRS comment parsing, with a note explaining comments were removed to save memory.

* **Refactor**
  * Removed comment extraction from APRS position parsing, reducing memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->