### PR TITLE
Update the scoring rules for Norway

### DIFF
--- a/libs/optimizer/src/lib/optimizer.spec.ts
+++ b/libs/optimizer/src/lib/optimizer.spec.ts
@@ -332,6 +332,7 @@ function getFlatTriangleMultiplier(scoringRules: ScoringRuleName) {
     case 'XContest':
       return 1.4;
     case 'Norway':
+      return 1.6;
     case 'UKClub':
     case 'UKNational':
       return 1.7;
@@ -361,7 +362,7 @@ function getFaiTriangleMultiplier(scoringRules: ScoringRuleName) {
     case 'CzechLocal':
       return 2.2;
     case 'Norway':
-      return 2.4;
+      return 1.8;
     case 'UKInternational':
       return 1.5;
     case 'XContestPPG':

--- a/libs/optimizer/src/lib/scoring-rules.ts
+++ b/libs/optimizer/src/lib/scoring-rules.ts
@@ -37,10 +37,10 @@ const leonardoRule = [
 
 const norwayRule = [
   { ...openDistance, multiplier: 1 },
-  { ...freeTriangle, multiplier: 1.7, closingDistanceRelative: 0.05 },
-  { ...freeTriangle, multiplier: 1.5, closingDistanceRelative: 0.2 },
-  { ...faiTriangle, multiplier: 2.4, closingDistanceRelative: 0.05 },
-  { ...faiTriangle, multiplier: 2.2, closingDistanceRelative: 0.2 },
+  { ...freeTriangle, multiplier: 1.6, closingDistanceRelative: 0.05 },
+  { ...freeTriangle, multiplier: 1.4, closingDistanceRelative: 0.2 },
+  { ...faiTriangle, multiplier: 1.8, closingDistanceRelative: 0.05 },
+  { ...faiTriangle, multiplier: 1.6, closingDistanceRelative: 0.2 },
 ];
 
 const ukXclClubRule = [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct Norway scoring multipliers for free and FAI triangle tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted scoring calculation multipliers to improve weighting accuracy for regional scoring rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->