### PR TITLE
windy plugin layer switcher

### DIFF
--- a/apps/fxc-tiles/eslint.config.js
+++ b/apps/fxc-tiles/eslint.config.js
@@ -3,6 +3,6 @@ const baseConfig = require('../../eslint.config.js');
 module.exports = [
   ...baseConfig,
   {
-    ignores: ['src/assets/airspaces/tiles/*'],
+    ignores: ['assets/tiles/*'],
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,6 @@ module.exports = [
       },
     })),
   {
-    ignores: ['**/.vite/', '**/.cache/', '**/node_modules/', '**/apps/fxc-tiles/src/assets/airspaces/'],
+    ignores: ['**/.vite/', '**/.cache/', '**/node_modules/', '**/apps/fxc-tiles/src/assets/airspaces/', 'dist/'],
   },
 ];

--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.17",
+  "version": "4.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-fxc-soundings",
-      "version": "4.1.17",
+      "version": "4.1.18",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.17",
+  "version": "4.1.18",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'preact/hooks';
+
 import { Watermark } from '../containers/containers.jsx';
 import * as atm from '../util/atmosphere.js';
 import type { CloudCoverGenerator } from '../util/clouds.js';
@@ -185,7 +187,71 @@ export function SkewT(props: SkewTProps) {
         )}
         <rect width={width} height={height} className="border" />
       </g>
+
+      <g>
+        <LayerSwitcher {...{ width, y: 35 }} />
+      </g>
     </svg>
+  );
+}
+
+/**
+ * Icons from https://www.svgrepo.com/collection/carbon-design-line-icons/
+ */
+function LayerSwitcher({ width, y }: { width: number; y: number }) {
+  const [overlay, setOverlay] = useState(W.store.get('overlay'));
+
+  const numLayers = 4;
+  const padding = 16;
+  const compWidth = (32 + padding) * numLayers;
+  const startX = width / 2 - compWidth / 2;
+
+  useEffect(() => {
+    const handleOverlayChange = (overlay: string) => {
+      setOverlay(overlay);
+    };
+
+    W.store.on('overlay', handleOverlayChange);
+
+    return () => {
+      W.store.off('overlay', handleOverlayChange);
+    };
+  }, []);
+
+  return (
+    <g transform={`translate(0, ${y})`}>
+      <g
+        transform={`translate(${startX})`}
+        x={startX}
+        className={`layer-icon ${overlay === 'clouds' ? 'active' : ''}`}
+        onPointerDown={() => W.store.set('overlay', 'clouds')}
+      >
+        <path d="m16 7 1.5.2a8 8 0 0 1 6.4 6.3l.2 1.3 1.4.3a5.5 5.5 0 0 1-1 10.9h-17a5.5 5.5 0 0 1-1-11l1.3-.2.3-1.3A8 8 0 0 1 16 7m0-2a10 10 0 0 0-9.8 8.1A7.5 7.5 0 0 0 7.5 28h17a7.5 7.5 0 0 0 1.3-14.9 10 10 0 0 0-8-8z" />
+      </g>
+      <g
+        transform={`translate(${startX + 48})`}
+        className={`layer-icon ${overlay === 'wind' ? 'active' : ''}`}
+        onPointerDown={() => W.store.set('overlay', 'wind')}
+      >
+        <path d="M21 15H8v-2h13a3 3 0 1 0-3-3h-2a5 5 0 1 1 5 5m2 13a5 5 0 0 1-5-5h2a3 3 0 1 0 3-3H4v-2h19a5 5 0 0 1 0 10" />
+      </g>
+      <g
+        transform={`translate(${startX + 96})`}
+        className={`layer-icon ${overlay === 'rain' ? 'active' : ''}`}
+        onPointerDown={() => W.store.set('overlay', 'rain')}
+      >
+        <path d="M16 24v-2a3.3 3.3 0 0 0 3-3h2a5.3 5.3 0 0 1-5 5" />
+        <path d="M16 28a9 9 0 0 1-9-9 10 10 0 0 1 1.5-5l6.7-10.6a1 1 0 0 1 1.6 0L23.5 14a10 10 0 0 1 1.5 5 9 9 0 0 1-9 9m0-22.2-5.8 9.3A8 8 0 0 0 9 19a7 7 0 0 0 14 0 8 8 0 0 0-1.2-4Z" />
+      </g>
+      <g
+        transform={`translate(${startX + 144})`}
+        className={`layer-icon ${overlay === 'ccl' ? 'active' : ''}`}
+        onPointerDown={() => W.store.set('overlay', 'ccl')}
+      >
+        <path d="m11 18 1.4 1.4 2.6-2.6V29h2V16.8l2.6 2.6L21 18l-5-5z" />
+        <path d="M23.5 22H23v-2h.5a4.5 4.5 0 0 0 .4-9H23l-.1-.8a7 7 0 0 0-13.9 0v.8h-.9a4.5 4.5 0 0 0 .4 9H9v2h-.5A6.5 6.5 0 0 1 7.2 9.1a9 9 0 0 1 17.6 0A6.5 6.5 0 0 1 23.5 22" />
+      </g>
+    </g>
   );
 }
 

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -253,7 +253,7 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
 
   const setIsZoomedIn = useCallback((expanded: boolean) => dispatch(pluginSlice.setIsZoomedIn(expanded)), []);
 
-  const { minPressure, maxPressure, isZoomedIn, levels, ghs, seaLevelPressure, surfaceElevation } = useSelector(
+  const { minPressure, maxPressure, isZoomedIn, levels, ghs, seaLevelPressure } = useSelector(
     (state: RootState) => {
       const timeMs = pluginSlice.selTimeMs(state);
       const isZoomedIn = pluginSlice.selIsZoomedIn(state);
@@ -277,7 +277,6 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
         levels: periodValues.levels,
         ghs: timeValues.gh,
         seaLevelPressure: timeValues.seaLevelPressure,
-        surfaceElevation: elevation,
       };
     },
     shallowEqual,
@@ -327,7 +326,7 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
         }
       }
     },
-    [levels, ghs, seaLevelPressure, minPressure, maxPressure, height, surfaceElevation],
+    [levels, ghs, seaLevelPressure, minPressure, maxPressure, height],
   );
 
   return (

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -538,7 +538,3 @@ function openMenu(e: KeyboardEvent | MouseEvent) {
     W.broadcast.emit('rqstOpen', 'menu');
   }
 }
-
-function openPluginMenu() {
-  W.broadcast.emit('rqstOpen', 'external-plugins');
-}

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -16,6 +16,8 @@ import { centerMap, changeLocation, updateTime } from '../redux/meta';
 import * as pluginSlice from '../redux/plugin-slice';
 import { type AppDispatch, type RootState } from '../redux/store';
 import * as unitsSlice from '../redux/units-slice';
+import * as atm from '../util/atmosphere';
+import * as math from '../util/math';
 import { formatTimestamp } from '../util/utils';
 
 // Plugin
@@ -251,35 +253,82 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
 
   const setIsZoomedIn = useCallback((expanded: boolean) => dispatch(pluginSlice.setIsZoomedIn(expanded)), []);
 
-  const { minPressure, maxPressure, isZoomedIn } = useSelector((state: RootState) => {
-    const timeMs = pluginSlice.selTimeMs(state);
-    const isZoomedIn = pluginSlice.selIsZoomedIn(state);
-    const modelName = pluginSlice.selModelName(state);
-    const location = pluginSlice.selLocation(state);
-    const elevation = forecastSlice.selElevation(state, modelName, location);
-    const minModelPressure = forecastSlice.selMinModelPressure(state, modelName, location);
-    const pressureToGhScale = forecastSlice.selPressureToGhScale(state, modelName, location, timeMs);
-    const minPressure = isZoomedIn
-      ? Math.round(Math.max(pressureToGhScale.invert(5200 + (elevation * 2) / 5), minModelPressure))
-      : minModelPressure;
-    const maxPressure = Math.min(1000, Math.round(pressureToGhScale.invert((elevation * 4) / 5)));
+  const { minPressure, maxPressure, isZoomedIn, levels, ghs, seaLevelPressure, surfaceElevation } = useSelector(
+    (state: RootState) => {
+      const timeMs = pluginSlice.selTimeMs(state);
+      const isZoomedIn = pluginSlice.selIsZoomedIn(state);
+      const modelName = pluginSlice.selModelName(state);
+      const location = pluginSlice.selLocation(state);
+      const elevation = forecastSlice.selElevation(state, modelName, location);
+      const minModelPressure = forecastSlice.selMinModelPressure(state, modelName, location);
+      const pressureToGhScale = forecastSlice.selPressureToGhScale(state, modelName, location, timeMs);
+      const minPressure = isZoomedIn
+        ? Math.round(Math.max(pressureToGhScale.invert(5200 + (elevation * 2) / 5), minModelPressure))
+        : minModelPressure;
+      const maxPressure = Math.min(1000, Math.round(pressureToGhScale.invert((elevation * 4) / 5)));
 
-    return { isZoomedIn, minPressure, maxPressure };
-  }, shallowEqual);
+      const periodValues = forecastSlice.selPeriodValues(state, modelName, location);
+      const timeValues = forecastSlice.selValuesAt(state, modelName, location, timeMs);
+
+      return {
+        isZoomedIn,
+        minPressure,
+        maxPressure,
+        levels: periodValues.levels,
+        ghs: timeValues.gh,
+        seaLevelPressure: timeValues.seaLevelPressure,
+        surfaceElevation: elevation,
+      };
+    },
+    shallowEqual,
+  );
 
   const skewTWidth = Math.round((width * skewTWidthPercent) / 100);
   const windWidth = width - skewTWidth - 5;
 
-  const moveCursor = useCallback((y: number | undefined) => {
-    if (y === undefined) {
-      // Do not remove the pointer on mobile.
-      if (!W.rootScope.isMobileOrTablet) {
-        setYpointer(undefined);
+  const moveCursor = useCallback(
+    (y: number | undefined) => {
+      if (y === undefined) {
+        // Do not remove the pointer on mobile.
+        if (!W.rootScope.isMobileOrTablet) {
+          setYpointer(undefined);
+        }
+      } else {
+        setYpointer(y);
+
+        const availLevels = W.store.get('availLevels');
+        if (availLevels && availLevels.length > 1) {
+          const pressureToGhScale = atm.getPressureToGhScale(levels, ghs, seaLevelPressure);
+          const ghMeterToPxScale = math.scaleLinear(
+            [pressureToGhScale(minPressure), pressureToGhScale(maxPressure)],
+            [0, height],
+          );
+          const yMeters = ghMeterToPxScale.invert(y);
+
+          const levelsWithElev = availLevels
+            .filter((level) => level.endsWith('h'))
+            .map((level) => {
+              const levelPressure = parseInt(level.slice(0, -1), 10);
+              return { level, elev: pressureToGhScale(levelPressure) };
+            });
+
+          levelsWithElev.sort((a, b) => a.elev - b.elev);
+
+          let selectedLevel = levelsWithElev[0].level;
+          for (const item of levelsWithElev) {
+            if (yMeters >= item.elev) {
+              selectedLevel = item.level;
+            }
+          }
+
+          if (selectedLevel && W.store.get('level') !== selectedLevel) {
+            W.store.set('level', selectedLevel);
+          }
+        }
       }
-    } else {
-      setYpointer(y);
-    }
-  }, []);
+    },
+    [levels, ghs, seaLevelPressure, minPressure, maxPressure, height, surfaceElevation],
+  );
 
   return (
     <g

--- a/libs/windy-sounding/src/redux/plugin-slice.ts
+++ b/libs/windy-sounding/src/redux/plugin-slice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { Fav } from '@windy/favs';
-import type { CompiledExternalPluginConfig, LatLon } from '@windy/interfaces';
+import type { LatLon } from '@windy/interfaces';
 
 import { getFavLabel, getSupportedModelName } from '../util/utils';
 import type { RootState } from './store';

--- a/libs/windy-sounding/src/styles.less
+++ b/libs/windy-sounding/src/styles.less
@@ -377,6 +377,23 @@
   }
 }
 
+.layer-icon {
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  opacity: 0.3;
+  pointer-events: bounding-box;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &.active {
+    opacity: 1;
+    fill: var(--color-orange);
+  }
+}
+
 // Mobile bottom bar.
 #plugin-windy-plugin-fxc-soundings {
   &.plugin-mobile-bottom-small {


### PR DESCRIPTION
## Summary by Sourcery

Add an interactive layer switcher to the Windy sounding SkewT view and align tooling configuration with updated asset locations.

New Features:
- Introduce a clickable overlay layer switcher in the SkewT chart for clouds, wind, rain, and CCL overlays.

Enhancements:
- Update cursor handling in the sounding graph to map pointer position to the nearest available pressure level and sync it with the global store.
- Simplify plugin slice typing by removing unused external plugin config type import.

Build:
- Adjust eslint ignore patterns for fxc-tiles assets and root dist output directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a layer switcher to the sounding view, enabling quick toggles between cloud, wind, rain, and CCL overlays.
  * Improved the graph cursor behavior by selecting and updating the most relevant level as you move across the chart.

* **Bug Fixes**
  * Refined lint ignore patterns to better exclude build output and the correct tiles asset path, reducing unnecessary lint noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->