### PR TITLE
update actions/checkout to  v7

### DIFF
--- a/.github/workflows/upload-windy-sounding.yml
+++ b/.github/workflows/upload-windy-sounding.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       WINDY_API_KEY: '${{ secrets.WINDY_API_KEY }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump actions/checkout from v4 to v7 in the upload-windy-sounding GitHub Actions workflow.