### PR TITLE
bump arcgis to 5.1

### DIFF
--- a/apps/fxc-front/src/app/components/3d/map3d-element.ts
+++ b/apps/fxc-front/src/app/components/3d/map3d-element.ts
@@ -215,9 +215,9 @@ export class Map3dElement extends connect(store)(LitElement) {
         }
       },
     );
-    // if (view.popup) {
-    //   view.popup.viewModel.includeDefaultActions = false;
-    // }
+    if (view.popup) {
+      view.popup.viewModel.includeDefaultActions = false;
+    }
     view.ui.remove('zoom');
 
     const controls = document.createElement('controls3d-element');

--- a/apps/fxc-front/src/app/components/3d/map3d-element.ts
+++ b/apps/fxc-front/src/app/components/3d/map3d-element.ts
@@ -8,12 +8,17 @@ import './tracking3d-element';
 import Basemap from '@arcgis/core/Basemap';
 import esriConfig from '@arcgis/core/config';
 import * as arcgisDecorators from '@arcgis/core/core/accessorSupport/decorators.js';
+import type { AbortOptions } from '@arcgis/core/core/promiseUtils';
 import { watch } from '@arcgis/core/core/reactiveUtils.js';
 import Point from '@arcgis/core/geometry/Point';
-import BaseElevationLayer from '@arcgis/core/layers/BaseElevationLayer';
+import BaseElevationLayer, {
+  type BaseElevationLayerProperties,
+  type FetchTileOptions,
+} from '@arcgis/core/layers/BaseElevationLayer';
 import ElevationLayer from '@arcgis/core/layers/ElevationLayer';
 import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
 import SceneLayer from '@arcgis/core/layers/SceneLayer';
+import type { ElevationTileData } from '@arcgis/core/layers/support/types';
 import TileLayer from '@arcgis/core/layers/TileLayer';
 import VectorTileLayer from '@arcgis/core/layers/VectorTileLayer';
 import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
@@ -210,9 +215,9 @@ export class Map3dElement extends connect(store)(LitElement) {
         }
       },
     );
-    if (view.popup) {
-      view.popup.viewModel.includeDefaultActions = false;
-    }
+    // if (view.popup) {
+    //   view.popup.viewModel.includeDefaultActions = false;
+    // }
     view.ui.remove('zoom');
 
     const controls = document.createElement('controls3d-element');
@@ -455,35 +460,29 @@ class ExaggeratedElevationLayer extends BaseElevationLayer {
   @arcgisDecorators.property()
   _elevation: ElevationLayer | undefined;
 
-  constructor(properties: __esri.BaseElevationLayerProperties & { multiplier: number }) {
+  constructor(properties: BaseElevationLayerProperties & { multiplier: number }) {
     super(properties);
     this.multiplier = properties.multiplier;
   }
 
-  load(): Promise<void> {
+  async load(options?: AbortOptions | null | undefined): Promise<this> {
     this._elevation = new ElevationLayer({
       url: 'https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
     });
-    const loadPromise = this._elevation.load();
+    const loadPromise = this._elevation.load(options);
     this.addResolvingPromise(loadPromise);
-    return loadPromise;
+    return this;
   }
 
-  async fetchTile(
-    level: number,
-    row: number,
-    col: number,
-    options?: __esri.BaseElevationLayerFetchTileOptions,
-  ): Promise<__esri.ElevationTileData> {
+  async fetchTile(level: number, row: number, col: number, options?: FetchTileOptions): Promise<ElevationTileData> {
     if (!this._elevation) {
       return {} as any;
     }
     const data = await this._elevation.fetchTile(level, row, col, options);
-    if (data.values) {
-      for (let i = 0; i < data.values.length; i++) {
-        data.values[i] *= this.multiplier;
-      }
+    const outData: number[] = [];
+    for (let i = 0; i < data.values.length; i++) {
+      outData[i] = data.values[i] * this.multiplier;
     }
-    return data;
+    return { ...data, values: outData };
   }
 }

--- a/apps/fxc-front/src/app/components/3d/map3d-element.ts
+++ b/apps/fxc-front/src/app/components/3d/map3d-element.ts
@@ -479,10 +479,10 @@ class ExaggeratedElevationLayer extends BaseElevationLayer {
       return {} as any;
     }
     const data = await this._elevation.fetchTile(level, row, col, options);
-    const outData: number[] = [];
     for (let i = 0; i < data.values.length; i++) {
-      outData[i] = data.values[i] * this.multiplier;
+      // Cast to make it writable, as the type is readonly.
+      (data.values as any)[i] *= this.multiplier;
     }
-    return { ...data, values: outData };
+    return data;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@alenaksu/json-viewer": "^2.1.2",
-        "@arcgis/core": "^4.34.8",
+        "@arcgis/core": "^5.1.0",
         "@date-fns/tz": "^1.4.1",
         "@dotenvx/dotenvx": "^1.51.4",
         "@dr.pogodin/csurf": "^1.16.7",
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@amcharts/amcharts5": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.14.4.tgz",
-      "integrity": "sha512-Tl7wQLWvsvyWVtlCIm1yhZtJviSDYjuNTnlUkO0D49GyByoK0nb9fr0DK4rUw4DVgyLcySxWBsb2lzTJm5Rd9Q==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.18.0.tgz",
+      "integrity": "sha512-2pIka1IrHO0mnTI7A9haq8aaq8leZZhFDythxNA7qYNg/iyGWuNcuzoyzJkybJLlNSlR5crkeNqZQL5up+IF3A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@types/d3": "^7.0.0",
@@ -240,7 +240,7 @@
         "d3-voronoi-treemap": "^1.1.2",
         "flatpickr": "^4.6.13",
         "markerjs2": "^2.29.4",
-        "pdfmake": "^0.2.2",
+        "pdfmake": "~0.3.9",
         "polylabel": "^1.1.0",
         "seedrandom": "^3.0.5",
         "svg-arc-to-cubic-bezier": "^3.2.0",
@@ -272,34 +272,34 @@
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.34.8.tgz",
-      "integrity": "sha512-UrEBTjXpSA9fhmmnAENBzz9GG81xALTezQFMXUs2iMB+tiOckmJyBbhATI/W4lIQyUfNEK7Zm/46EP2PhDga/A==",
-      "license": "SEE LICENSE IN copyright.txt",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-5.1.10.tgz",
+      "integrity": "sha512-3TLhR+zq34gCeKwKonhaKbx8N2zgAeRO+ULegNyKrCfrUZj8aYdDouNSACOxDcoNI71KTB8zW+L/vbExRaIMQA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@amcharts/amcharts5": "~5.14.1",
-        "@arcgis/toolkit": "^4.34.0",
+        "@amcharts/amcharts5": "~5.18.0",
+        "@arcgis/toolkit": "^5.1.0",
         "@esri/arcgis-html-sanitizer": "~4.1.0",
-        "@esri/calcite-components": "^3.3.2",
-        "@vaadin/grid": "~24.9.1",
-        "@zip.js/zip.js": "~2.8.7",
+        "@esri/calcite-components": "^5.1.1",
+        "@vaadin/grid": "~25.1.4",
+        "@zip.js/zip.js": "~2.8.26",
         "luxon": "~3.7.2",
-        "marked": "~16.3.0",
+        "marked": "~18.0.5",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@arcgis/lumina": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.34.9.tgz",
-      "integrity": "sha512-efqO+SwR+1IYf29AATh1l2FUeypRyRINTBNkaJY+KkaFe+8gqSJ45qOmputhyzF5WTRDb7WhOYgnChjp6VYPpA==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-5.1.10.tgz",
+      "integrity": "sha512-lAsGvtxnMq2YYvANXICPxMDA0q/VHHH76a6Vb45YAjXRTiIk6EjwwJ7hy6I6J+y7apdGxo9J0CoxhLQsMpfVyQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@arcgis/toolkit": "~4.34.9",
+        "@arcgis/toolkit": "~5.1.10",
         "csstype": "^3.1.3",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "@lit/context": "^1.1.5",
+        "@lit/context": "^1.1.6",
         "lit": "^3.3.0"
       },
       "peerDependenciesMeta": {
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@arcgis/toolkit": {
-      "version": "4.34.9",
-      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-4.34.9.tgz",
-      "integrity": "sha512-wFST+eVnCwmg9NyICVyn9bsBnR+TlWklsGqG3L7xqSTgfXo6TuCThE7wtTb8xWxsTBkGvImqMUgpgLuwQuTQ1g==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.1.10.tgz",
+      "integrity": "sha512-pOxk9Tbj370+le/uC4VuLAFrNJO/Fop8nUmy47mVrdRKwbX5eTeaTiDV1Q2raIGCbvH1z+Po/Y18RLpVKcnCgQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -3321,21 +3321,21 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.3.3.tgz",
-      "integrity": "sha512-tw+EfJ3pb+Odj71W6E9GUkm8rMbNxfW1KeiI8GgsKDzhr39hMKwY+zYYFFYuO0FONxWGvAB+B8yqB0NvH7WeHw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-5.1.2.tgz",
+      "integrity": "sha512-KdCk68T+UzVeAMA+kHW5UZ8msedBAH10k1J9Vkhqc8DtpJ0L/j2rw0ve9pbq1sW+hAAbhnTj+0OyP3R5bp1dEg==",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/lumina": ">=4.34.0-next.158 <4.35.0",
-        "@arcgis/toolkit": ">=4.34.0-next.158 <4.35.0",
-        "@esri/calcite-ui-icons": "4.3.0",
+        "@arcgis/lumina": ">=5.1.0-next.96 <6.0.0",
+        "@arcgis/toolkit": ">=5.1.0-next.96 <6.0.0",
+        "@esri/calcite-ui-icons": "4.5.0",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
-        "color": "^5.0.0",
+        "color": "^5.0.3",
         "composed-offset-position": "^0.0.6",
         "es-toolkit": "^1.39.8",
-        "focus-trap": "^7.6.5",
+        "focus-trap": "^8.2.1",
         "interactjs": "^1.10.27",
         "lit": "^3.3.0",
         "sortablejs": "^1.15.6",
@@ -3344,9 +3344,9 @@
       }
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.3.0.tgz",
-      "integrity": "sha512-iOOuRurpjFxFVw6+aXW2JpSkRBrdOpBcbdibfPOmSPqMd1aoHBtYmYXetKoH9vfrXoBiPyO2PkDnczhsu/N9IA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.5.0.tgz",
+      "integrity": "sha512-MuXK8o5qefXXV/vdDucQUm8zno+9Q0KjadCX82gYX1VgHMLPp0x2+pbQzG3c0MDbRqkidhTqL/zwq/eVq282qg==",
       "license": "SEE LICENSE.md",
       "bin": {
         "spriter": "bin/spriter.js"
@@ -3363,79 +3363,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
-    },
-    "node_modules/@foliojs-fork/fontkit": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
-      "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
-      "license": "MIT",
-      "dependencies": {
-        "@foliojs-fork/restructure": "^2.0.2",
-        "brotli": "^1.2.0",
-        "clone": "^1.0.4",
-        "deep-equal": "^1.0.0",
-        "dfa": "^1.2.0",
-        "tiny-inflate": "^1.0.2",
-        "unicode-properties": "^1.2.2",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/linebreak": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
-      "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "1.3.1",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/linebreak/node_modules/base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "license": "MIT"
-    },
-    "node_modules/@foliojs-fork/pdfkit": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
-      "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
-      "license": "MIT",
-      "dependencies": {
-        "@foliojs-fork/fontkit": "^1.9.2",
-        "@foliojs-fork/linebreak": "^1.1.1",
-        "crypto-js": "^4.2.0",
-        "jpeg-exif": "^1.1.4",
-        "png-js": "^1.0.0"
-      }
-    },
-    "node_modules/@foliojs-fork/restructure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
-      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@google-cloud/compute": {
@@ -7483,15 +7432,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@polymer/polymer": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
-      "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@webcomponents/shadycss": "^1.9.1"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -8793,7 +8733,6 @@
       "version": "0.5.18",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -9223,9 +9162,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-sankey": {
@@ -9274,9 +9213,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -10155,131 +10094,102 @@
       "license": "ISC"
     },
     "node_modules/@vaadin/a11y-base": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.9.7.tgz",
-      "integrity": "sha512-JkF2kGYmFIr5CAIKPJjI8qZY51LGauah37Z7EZD1tD95vLbyRQVtE8CtumeZXwvJOoKv5t8tLvYTMn0z53jW0w==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-25.1.6.tgz",
+      "integrity": "sha512-NQ1xR+TQm1IJO1hU8ssOwua/WViNwqTHT85+hLnv9PnN5pTCWQVyEwhIvskpqGmONXe5+b9U5ZhI0Ese8wVqZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.7",
+        "@vaadin/component-base": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/checkbox": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.9.7.tgz",
-      "integrity": "sha512-UQG7AAArC/dI7p+QpaBQPDtzSHPVEK+24s5HiqnUYDGQUvU/XvSa5oYWDO+BqqHn4IZLS0dp+g9tAmkxt5fI2A==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-25.1.6.tgz",
+      "integrity": "sha512-CTqQZtHnB13EcuUUFqUjpc55fryK30yRI9sunl1XxIbB1TiNp59U+XSeetZA63BGJoG8fqRiAGjCZ4rMCJeCJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.7",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/field-base": "~24.9.7",
-        "@vaadin/vaadin-lumo-styles": "~24.9.7",
-        "@vaadin/vaadin-material-styles": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7",
+        "@vaadin/a11y-base": "~25.1.6",
+        "@vaadin/component-base": "~25.1.6",
+        "@vaadin/field-base": "~25.1.6",
+        "@vaadin/vaadin-themable-mixin": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/component-base": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.9.7.tgz",
-      "integrity": "sha512-9IsgcC0rF7iitcnoa9q3TnnOtMeBtPjq6RXdcgux5FZTefpCWCEvv+hq8IiXMpalM5Fm9NuhFsp6T08haczU+g==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-25.1.6.tgz",
+      "integrity": "sha512-YJI86x6f6lPtZJ7o0ciLmJ/LAeC4gD0fNaWdkE7gHUoRe+YC+6VdpoC7BkhLDH9sRrdHPMA0TxBkkTrcmzIlFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-usage-statistics": "^2.1.0",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/field-base": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.9.7.tgz",
-      "integrity": "sha512-+Rj1LvKXeTNbvOfxq2QRjsAD95lIVAZmy/TCAh49rfDd5eUh94qxgrMnaBFbIU+g+byTszPAVySkdHZo52C+Qg==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-25.1.6.tgz",
+      "integrity": "sha512-HQ/BnBIIyJWstsztTBTej7XOAMZXtgkJVOKjraV6XOQib2geNJo+ljv8iZvC3byKzDg58dTg2ZNI74i23czwVg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.7",
-        "@vaadin/component-base": "~24.9.7",
+        "@vaadin/a11y-base": "~25.1.6",
+        "@vaadin/component-base": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/grid": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.9.7.tgz",
-      "integrity": "sha512-4aPxH32BG5TRlans8t3895f3qeciH4XRYuu62RCfOw/dEYlCpwNftnJX2HPv0Goj1AgdNAq24TijKYPxLa/WAQ==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-25.1.6.tgz",
+      "integrity": "sha512-1GCs1RC8Dsl5Ak6v5sJKu0Z/b1TLV+0XUyNd/49uETGFKXjZMzJhKUKafn8xJjRfb325kEkieBtbbphN1WbnJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.7",
-        "@vaadin/checkbox": "~24.9.7",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/lit-renderer": "~24.9.7",
-        "@vaadin/text-field": "~24.9.7",
-        "@vaadin/vaadin-lumo-styles": "~24.9.7",
-        "@vaadin/vaadin-material-styles": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/icon": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.9.7.tgz",
-      "integrity": "sha512-H1BmjZeo0XKVe4xoIt1INp7TdbwAOM+hoe3T+EZUJPjwn20iGRPI3iupGVEoySeh8fQnXzyV9fFMlitMmeYFyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/vaadin-lumo-styles": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7",
+        "@vaadin/a11y-base": "~25.1.6",
+        "@vaadin/checkbox": "~25.1.6",
+        "@vaadin/component-base": "~25.1.6",
+        "@vaadin/lit-renderer": "~25.1.6",
+        "@vaadin/text-field": "~25.1.6",
+        "@vaadin/vaadin-themable-mixin": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/input-container": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.9.7.tgz",
-      "integrity": "sha512-KZ8EAakEOWi+yAub3RYyT8HDLwFSsN7ty50jJWqQcRxJ8F+lCGXYc/9MBDNAK6rq9r++urbyc9HaJZydUvYcZg==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-25.1.6.tgz",
+      "integrity": "sha512-smoW1NQZMSYgqW4lWsiXoYSITM50uM/x2O2VUiHDoJncNChpo6E2qMV1HGrdlt9VCr7+SQrnp/K5/4N1gbQGYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/vaadin-lumo-styles": "~24.9.7",
-        "@vaadin/vaadin-material-styles": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7",
+        "@vaadin/component-base": "~25.1.6",
+        "@vaadin/vaadin-themable-mixin": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/lit-renderer": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.9.7.tgz",
-      "integrity": "sha512-WZriGHq8Iz2Rl7mVy0XXybNPrxx3VHV9jgZebXMORfDJkHGF/azLd+ElX6cMiIemWVft9SNWkeZ8x83oITHxlQ==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-25.1.6.tgz",
+      "integrity": "sha512-Kb44Ah/VoY+Tq2qkGJsbOcV2YEb4bmVM+Fu/l/HD74ukXkOdFjGWc+VnIcz3iocxOY1ImKP2NpeI3NK0UoQ8BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/text-field": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.9.7.tgz",
-      "integrity": "sha512-p8OO2kJGoYjlvmfjZst1oMPeFYwXav83/H5FH/2A4cXJh9gInFYcReoTA9Xvmf2zfVuMfPZO73X8yOKd0e52IA==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-25.1.6.tgz",
+      "integrity": "sha512-s9xgWuAvn3C+V9OMstcOqovhqAQYrmVYRYcUnrMM28nqE9UM0h3p+E+04XfdFaMTdVbxZc2a1jPYZp+YiKWV7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.9.7",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/field-base": "~24.9.7",
-        "@vaadin/input-container": "~24.9.7",
-        "@vaadin/vaadin-lumo-styles": "~24.9.7",
-        "@vaadin/vaadin-material-styles": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7",
+        "@vaadin/a11y-base": "~25.1.6",
+        "@vaadin/component-base": "~25.1.6",
+        "@vaadin/field-base": "~25.1.6",
+        "@vaadin/input-container": "~25.1.6",
+        "@vaadin/vaadin-themable-mixin": "~25.1.6",
         "lit": "^3.0.0"
       }
     },
@@ -10289,38 +10199,15 @@
       "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.9.7.tgz",
-      "integrity": "sha512-sxceUR2740h/Ah9puwOHuDNomDQwJcAAh5xYoHIWAKNQtEuNdvvzmodlZtLiTHkRqcaPWbqefI8mfDCCcF0VJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/icon": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7"
-      }
-    },
-    "node_modules/@vaadin/vaadin-material-styles": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.9.7.tgz",
-      "integrity": "sha512-+1sJ/sQSs0GAe1CwljEakZD6fkciJZKbB1vvAySX6YShBzeG14UakY/Uv5Kflwpqu2qcyHAlxHIBMEf2s9+VwA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.9.7",
-        "@vaadin/vaadin-themable-mixin": "~24.9.7"
-      }
-    },
     "node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.9.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.9.7.tgz",
-      "integrity": "sha512-NqUMCxaJzDtdl2wLKeeqrEryvxcFFhj0twFaAhPzzAmcJvD6/MO7CkE/zzyynaZ8qhfo8ocXYGRpxC8fAJSCgA==",
+      "version": "25.1.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.1.6.tgz",
+      "integrity": "sha512-LIeW+3iW6ZfQhjlQJ2cqMOF4rSL9QQqwLqWxIH/Elu2Ernxi9pe6480R8pOwAr2LfMWcu/TiwQJQ4z6ASJGcGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0",
-        "style-observer": "^0.0.8"
+        "@vaadin/component-base": "~25.1.6",
+        "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/vaadin-usage-statistics": {
@@ -10872,12 +10759,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webcomponents/shadycss": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -10947,9 +10828,9 @@
       }
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
-      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
+      "version": "2.8.26",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
@@ -12264,6 +12145,15 @@
         "base64-js": "^1.1.2"
       }
     },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.26.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
@@ -12428,6 +12318,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -12814,6 +12705,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -13369,12 +13261,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -14035,9 +13921,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -14570,26 +14456,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -14664,6 +14530,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -14691,6 +14558,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -14712,9 +14580,9 @@
       "license": "MIT"
     },
     "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -15476,9 +15344,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
-      "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -16594,7 +16462,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -16992,12 +16859,12 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.7.1.tgz",
-      "integrity": "sha512-Pkp8m55GjxBLnhBoT6OXdMvfRr4TjMAKLvFM566zlIryq5plbhaTmLAJWTGR0EkRwLjEte1lCOG9MxF1ipJrOg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+      "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
       "license": "MIT",
       "dependencies": {
-        "tabbable": "^6.4.0"
+        "tabbable": "^6.5.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -17018,6 +16885,32 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/for-each": {
@@ -17349,6 +17242,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18068,6 +17962,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -18876,22 +18771,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -19063,6 +18942,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -19357,6 +19237,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -20690,17 +20571,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jpeg-exif": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
-      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
-      "license": "MIT"
-    },
     "node_modules/js-levenshtein-esm": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
       "integrity": "sha512-fzreKVq1eD7eGcQr7MtRpQH94f8gIfhdrc7yeih38xh684TNMK9v5aAu2wxfIRMk/GpAJRrzcirMAPIaSDaByQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -21242,6 +21123,25 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -21688,9 +21588,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/marked": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
-      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -22746,26 +22646,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -23364,35 +23249,32 @@
         "node": "*"
       }
     },
-    "node_modules/pdfmake": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.21.tgz",
-      "integrity": "sha512-kgBj6Bbj57vY/f0zpBz/OLmO4n248RopEEA+IRkfdKZtravqQL6lEkILYsdjiPFYCXImZA+62EtT2zjUVKb8YQ==",
+    "node_modules/pdfkit": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
       "license": "MIT",
       "dependencies": {
-        "@foliojs-fork/linebreak": "^1.1.2",
-        "@foliojs-fork/pdfkit": "^0.15.3",
-        "iconv-lite": "^0.7.1",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.1.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.11.tgz",
+      "integrity": "sha512-Uc49J9hUMyuqJk+U+PxlpBpPr96A4HOOfesGx609EPr2ue82+5/Smq/KTAkEqh0/jUGSi1fumvqZ5yAWijJTJg==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.19.1",
         "xmldoc": "^2.0.3"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/pdfmake/node_modules/iconv-lite": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">=20"
       }
     },
     "node_modules/pend": {
@@ -23600,9 +23482,12 @@
       "license": "MIT"
     },
     "node_modules/png-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
     },
     "node_modules/pngjs": {
       "version": "7.0.0",
@@ -25024,6 +24909,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -25249,6 +25135,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -25336,9 +25228,9 @@
       "license": "MIT"
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -26126,6 +26018,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -26143,6 +26036,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -26532,9 +26426,9 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
       "license": "MIT"
     },
     "node_modules/source-map": {
@@ -27101,22 +26995,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/style-observer": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/style-observer/-/style-observer-0.0.8.tgz",
-      "integrity": "sha512-UaIPn33Sx4BJ+goia51Q++VFWoplWK1995VdxQYzwwbFa+FUNLKlG+aiIdG2Vw7VyzIUBi8tqu8mTyg0Ppu6Yg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/LeaVerou"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/leaverou"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/stylehacks": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
@@ -27465,9 +27343,9 @@
       "license": "MIT"
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@alenaksu/json-viewer": "^2.1.2",
-    "@arcgis/core": "^4.34.8",
+    "@arcgis/core": "^5.1.0",
     "@date-fns/tz": "^1.4.1",
     "@dotenvx/dotenvx": "^1.51.4",
     "@dr.pogodin/csurf": "^1.16.7",


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the ArcGIS JS SDK to v5.1 and adapt the custom 3D elevation layer to the new API.

Enhancements:
- Update the exaggerated elevation layer implementation to use the new ArcGIS 5.x type definitions and load/fetchTile contracts while preserving height exaggeration behavior.

Build:
- Bump @arcgis/core dependency from 4.34.8 to 5.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D map elevation tile processing to enhance terrain rendering reliability and correctness.
* **Chores**
  * Updated the ArcGIS mapping library to a newer version for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->