### PR TITLE
Vicb/windy switcher ff

### DIFF
--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.19",
+  "version": "4.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-fxc-soundings",
-      "version": "4.1.19",
+      "version": "4.1.20",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",

--- a/libs/windy-sounding/package-lock.json
+++ b/libs/windy-sounding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.18",
+  "version": "4.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-fxc-soundings",
-      "version": "4.1.18",
+      "version": "4.1.19",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.18",
+  "version": "4.1.19",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "4.1.19",
+  "version": "4.1.20",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -201,16 +201,19 @@ export function SkewT(props: SkewTProps) {
 const LAYERS = [
   {
     name: 'clouds',
+    label: 'Clouds',
     paths: [
       'm16 7 1.5.2a8 8 0 0 1 6.4 6.3l.2 1.3 1.4.3a5.5 5.5 0 0 1-1 10.9h-17a5.5 5.5 0 0 1-1-11l1.3-.2.3-1.3A8 8 0 0 1 16 7m0-2a10 10 0 0 0-9.8 8.1A7.5 7.5 0 0 0 7.5 28h17a7.5 7.5 0 0 0 1.3-14.9 10 10 0 0 0-8-8z',
     ],
   },
   {
     name: 'wind',
+    label: 'Wind',
     paths: ['M21 15H8v-2h13a3 3 0 1 0-3-3h-2a5 5 0 1 1 5 5m2 13a5 5 0 0 1-5-5h2a3 3 0 1 0 3-3H4v-2h19a5 5 0 0 1 0 10'],
   },
   {
     name: 'rain',
+    label: 'Rain',
     paths: [
       'M16 24v-2a3.3 3.3 0 0 0 3-3h2a5.3 5.3 0 0 1-5 5',
       'M16 28a9 9 0 0 1-9-9 10 10 0 0 1 1.5-5l6.7-10.6a1 1 0 0 1 1.6 0L23.5 14a10 10 0 0 1 1.5 5 9 9 0 0 1-9 9m0-22.2-5.8 9.3A8 8 0 0 0 9 19a7 7 0 0 0 14 0 8 8 0 0 0-1.2-4Z',
@@ -218,6 +221,7 @@ const LAYERS = [
   },
   {
     name: 'ccl',
+    label: 'Convective Condensation Level (CCL)',
     paths: [
       'm11 18 1.4 1.4 2.6-2.6V29h2V16.8l2.6 2.6L21 18l-5-5z',
       'M23.5 22H23v-2h.5a4.5 4.5 0 0 0 .4-9H23l-.1-.8a7 7 0 0 0-13.9 0v.8h-.9a4.5 4.5 0 0 0 .4 9H9v2h-.5A6.5 6.5 0 0 1 7.2 9.1a9 9 0 0 1 17.6 0A6.5 6.5 0 0 1 23.5 22',
@@ -246,12 +250,22 @@ function LayerSwitcher({ width, y }: { width: number; y: number }) {
 
   return (
     <g transform={`translate(0, ${y})`}>
-      {LAYERS.map(({ name, paths }, idx) => (
+      {LAYERS.map(({ name, label, paths }, idx) => (
         <g
           key={name}
           transform={`translate(${startX + idx * (32 + padding)})`}
           className={`layer-icon ${overlay === name ? 'active' : ''}`}
           onPointerDown={() => W.store.set('overlay', name)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              W.store.set('overlay', name);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={label}
+          aria-pressed={overlay === name}
         >
           <rect width={32} height={32} />
           {paths.map((d, pathIdx) => (

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -198,12 +198,38 @@ export function SkewT(props: SkewTProps) {
 /**
  * Icons from https://www.svgrepo.com/collection/carbon-design-line-icons/
  */
+const LAYERS = [
+  {
+    name: 'clouds',
+    paths: [
+      'm16 7 1.5.2a8 8 0 0 1 6.4 6.3l.2 1.3 1.4.3a5.5 5.5 0 0 1-1 10.9h-17a5.5 5.5 0 0 1-1-11l1.3-.2.3-1.3A8 8 0 0 1 16 7m0-2a10 10 0 0 0-9.8 8.1A7.5 7.5 0 0 0 7.5 28h17a7.5 7.5 0 0 0 1.3-14.9 10 10 0 0 0-8-8z',
+    ],
+  },
+  {
+    name: 'wind',
+    paths: ['M21 15H8v-2h13a3 3 0 1 0-3-3h-2a5 5 0 1 1 5 5m2 13a5 5 0 0 1-5-5h2a3 3 0 1 0 3-3H4v-2h19a5 5 0 0 1 0 10'],
+  },
+  {
+    name: 'rain',
+    paths: [
+      'M16 24v-2a3.3 3.3 0 0 0 3-3h2a5.3 5.3 0 0 1-5 5',
+      'M16 28a9 9 0 0 1-9-9 10 10 0 0 1 1.5-5l6.7-10.6a1 1 0 0 1 1.6 0L23.5 14a10 10 0 0 1 1.5 5 9 9 0 0 1-9 9m0-22.2-5.8 9.3A8 8 0 0 0 9 19a7 7 0 0 0 14 0 8 8 0 0 0-1.2-4Z',
+    ],
+  },
+  {
+    name: 'ccl',
+    paths: [
+      'm11 18 1.4 1.4 2.6-2.6V29h2V16.8l2.6 2.6L21 18l-5-5z',
+      'M23.5 22H23v-2h.5a4.5 4.5 0 0 0 .4-9H23l-.1-.8a7 7 0 0 0-13.9 0v.8h-.9a4.5 4.5 0 0 0 .4 9H9v2h-.5A6.5 6.5 0 0 1 7.2 9.1a9 9 0 0 1 17.6 0A6.5 6.5 0 0 1 23.5 22',
+    ],
+  },
+];
+
 function LayerSwitcher({ width, y }: { width: number; y: number }) {
   const [overlay, setOverlay] = useState(W.store.get('overlay'));
 
-  const numLayers = 4;
   const padding = 16;
-  const compWidth = (32 + padding) * numLayers;
+  const compWidth = 32 * LAYERS.length + padding * (LAYERS.length - 1);
   const startX = width / 2 - compWidth / 2;
 
   useEffect(() => {
@@ -220,37 +246,19 @@ function LayerSwitcher({ width, y }: { width: number; y: number }) {
 
   return (
     <g transform={`translate(0, ${y})`}>
-      <g
-        transform={`translate(${startX})`}
-        x={startX}
-        className={`layer-icon ${overlay === 'clouds' ? 'active' : ''}`}
-        onPointerDown={() => W.store.set('overlay', 'clouds')}
-      >
-        <path d="m16 7 1.5.2a8 8 0 0 1 6.4 6.3l.2 1.3 1.4.3a5.5 5.5 0 0 1-1 10.9h-17a5.5 5.5 0 0 1-1-11l1.3-.2.3-1.3A8 8 0 0 1 16 7m0-2a10 10 0 0 0-9.8 8.1A7.5 7.5 0 0 0 7.5 28h17a7.5 7.5 0 0 0 1.3-14.9 10 10 0 0 0-8-8z" />
-      </g>
-      <g
-        transform={`translate(${startX + 48})`}
-        className={`layer-icon ${overlay === 'wind' ? 'active' : ''}`}
-        onPointerDown={() => W.store.set('overlay', 'wind')}
-      >
-        <path d="M21 15H8v-2h13a3 3 0 1 0-3-3h-2a5 5 0 1 1 5 5m2 13a5 5 0 0 1-5-5h2a3 3 0 1 0 3-3H4v-2h19a5 5 0 0 1 0 10" />
-      </g>
-      <g
-        transform={`translate(${startX + 96})`}
-        className={`layer-icon ${overlay === 'rain' ? 'active' : ''}`}
-        onPointerDown={() => W.store.set('overlay', 'rain')}
-      >
-        <path d="M16 24v-2a3.3 3.3 0 0 0 3-3h2a5.3 5.3 0 0 1-5 5" />
-        <path d="M16 28a9 9 0 0 1-9-9 10 10 0 0 1 1.5-5l6.7-10.6a1 1 0 0 1 1.6 0L23.5 14a10 10 0 0 1 1.5 5 9 9 0 0 1-9 9m0-22.2-5.8 9.3A8 8 0 0 0 9 19a7 7 0 0 0 14 0 8 8 0 0 0-1.2-4Z" />
-      </g>
-      <g
-        transform={`translate(${startX + 144})`}
-        className={`layer-icon ${overlay === 'ccl' ? 'active' : ''}`}
-        onPointerDown={() => W.store.set('overlay', 'ccl')}
-      >
-        <path d="m11 18 1.4 1.4 2.6-2.6V29h2V16.8l2.6 2.6L21 18l-5-5z" />
-        <path d="M23.5 22H23v-2h.5a4.5 4.5 0 0 0 .4-9H23l-.1-.8a7 7 0 0 0-13.9 0v.8h-.9a4.5 4.5 0 0 0 .4 9H9v2h-.5A6.5 6.5 0 0 1 7.2 9.1a9 9 0 0 1 17.6 0A6.5 6.5 0 0 1 23.5 22" />
-      </g>
+      {LAYERS.map(({ name, paths }, idx) => (
+        <g
+          key={name}
+          transform={`translate(${startX + idx * (32 + padding)})`}
+          className={`layer-icon ${overlay === name ? 'active' : ''}`}
+          onPointerDown={() => W.store.set('overlay', name)}
+        >
+          <rect width={32} height={32} />
+          {paths.map((d, pathIdx) => (
+            <path key={pathIdx} d={d} />
+          ))}
+        </g>
+      ))}
     </g>
   );
 }

--- a/libs/windy-sounding/src/sounding.tsx
+++ b/libs/windy-sounding/src/sounding.tsx
@@ -137,7 +137,7 @@ export const destroyPlugin = () => {
 function setSizeFrom(container: HTMLElement) {
   const padding = W.rootScope.isMobileOrTablet ? 0 : 50;
   const width = container.clientWidth - padding;
-  const height = Math.min(width, window.innerHeight * 0.7);
+  const height = Math.round(Math.min(width, window.innerHeight * 0.7));
   store.dispatch(pluginSlice.setWidth(width));
   store.dispatch(pluginSlice.setHeight(height));
 }

--- a/libs/windy-sounding/src/styles.less
+++ b/libs/windy-sounding/src/styles.less
@@ -382,7 +382,10 @@
   width: 32px;
   height: 32px;
   opacity: 0.3;
-  pointer-events: bounding-box;
+
+  rect {
+    fill: transparent;
+  }
 
   &:hover {
     opacity: 0.8;
@@ -390,7 +393,10 @@
 
   &.active {
     opacity: 1;
-    fill: var(--color-orange);
+
+    path {
+      fill: var(--color-orange);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the SkewT layer switcher to use a data-driven configuration for overlays and adjust sizing, styling, and plugin dimensions accordingly.

New Features:
- Introduce a configurable LAYERS definition to drive the overlay switcher icons and behavior.

Enhancements:
- Simplify and generalize the LayerSwitcher rendering by mapping over the LAYERS configuration instead of hardcoding each icon.
- Adjust layer icon layout calculations and add a transparent rect to provide a consistent clickable area.
- Round the computed plugin height to avoid fractional dimensions in the sounding layout.

Build:
- Bump windy-sounding plugin version from 4.1.18 to 4.1.19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the overlay layer switcher with data-driven layer support, improved interaction, and accessibility enhancements (keyboard support and ARIA states).

* **Bug Fixes**
  * Refined overlay icon hover/active styling to ensure the correct SVG elements update visually.
  * Rounded the sounding panel height calculation to provide consistent, whole-number sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->