### PR TITLE
A couple fixes for the windy plugin

### DIFF
--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "5.0.2",
+  "version": "5.0.4",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/favorites.tsx
+++ b/libs/windy-sounding/src/components/favorites.tsx
@@ -98,8 +98,11 @@ export function Favorites({ favorites, location, isMobile, onSelected, onSelectM
             ) : (
               favorites.map((favorite: Fav) => (
                 <span
+                  key={latLon2Str(favorite)}
                   className={latLon2Str(favorite) == locationStr ? 'selected' : ''}
-                  onClick={() => onSelected({ lat: favorite.lat, lon: favorite.lon })}
+                  onClick={() => {
+                    onSelected({ lat: favorite.lat, lon: favorite.lon });
+                  }}
                 >
                   {getFavLabel(favorite)}
                 </span>

--- a/libs/windy-sounding/src/redux/forecast-slice.ts
+++ b/libs/windy-sounding/src/redux/forecast-slice.ts
@@ -12,7 +12,7 @@ import {
   saturationVaporPressure,
 } from '../util/atmosphere';
 import type { Scale } from '../util/math';
-import { sampleAt, scaleLinear } from '../util/math';
+import { lerpAngleDegree, sampleAt, scaleLinear } from '../util/math';
 import { latLon2Str } from '../util/utils';
 import * as pluginSlice from './plugin-slice';
 import type { AppThunkAPI, RootState } from './store';
@@ -515,7 +515,7 @@ export const selValuesAt = createSelector(
       gh: sampleAt(timesMs, periodValues.ghByTime, timeMs),
       rh: sampleAt(timesMs, periodValues.rhByTime, timeMs),
       wind: sampleAt(timesMs, periodValues.windByTime, timeMs),
-      windDir: sampleAt(timesMs, periodValues.windDirByTime, timeMs),
+      windDir: sampleAt(timesMs, periodValues.windDirByTime, timeMs, lerpAngleDegree),
       cloud: sampleAt(timesMs, periodValues.cloudByTime, timeMs),
       rainMm: sampleAt(timesMs, periodValues.rainMmByTime, timeMs),
       seaLevelPressure: sampleAt(timesMs, periodValues.seaLevelPressureByTime, timeMs),

--- a/libs/windy-sounding/src/redux/meta.ts
+++ b/libs/windy-sounding/src/redux/meta.ts
@@ -111,6 +111,9 @@ function updateUrl(state: RootState) {
 let marker: L.Marker | undefined;
 
 export function maybeCreateAndMoveMarker(location: LatLon) {
+  if (location.lat === 0 && location.lon === 0) {
+    return;
+  }
   const { lon: lng, lat } = location;
   if (marker) {
     marker.setLatLng({ lat, lng });

--- a/libs/windy-sounding/src/sounding.tsx
+++ b/libs/windy-sounding/src/sounding.tsx
@@ -115,28 +115,6 @@ export const mountPlugin = (container: HTMLElement) => {
     dispatch(pluginSlice.setFavorites(await favs.getAll()));
   });
   addSubscription(() => broadcast.off(favChangedEventId));
-
-  // Debounce map moveend to avoid excessive forecast fetches on frequent panning
-  let moveEndTimeout: number | undefined;
-
-  const mapMoveEndHandler = () => {
-    if (moveEndTimeout) {
-      clearTimeout(moveEndTimeout);
-    }
-
-    moveEndTimeout = window.setTimeout(() => {
-      const center = windyMap.getCenter();
-      dispatch(changeLocation({ lat: center.lat, lon: center.lng }));
-    }, 100);
-  };
-
-  windyMap.on('moveend', mapMoveEndHandler);
-  addSubscription(() => {
-    windyMap.off('moveend', mapMoveEndHandler);
-    if (moveEndTimeout) {
-      clearTimeout(moveEndTimeout);
-    }
-  });
 };
 
 // Called when the plugin is opened

--- a/libs/windy-sounding/src/util/math.test.ts
+++ b/libs/windy-sounding/src/util/math.test.ts
@@ -2,6 +2,7 @@ import {
   composeScales,
   firstIntersection,
   lerp,
+  lerpAngleDegree,
   linearInterpolate,
   round,
   sampleAt,
@@ -27,6 +28,42 @@ describe('lerp', () => {
   it('should return the correct value for any weight', () => {
     expect(lerp(10, 20, 0.25)).toEqual(12.5);
     expect(lerp(10, 20, 0.75)).toEqual(17.5);
+  });
+});
+
+describe('lerpAngleDegree', () => {
+  it('should return a when weight is 0', () => {
+    expect(lerpAngleDegree(350, 10, 0)).toEqual(350);
+    expect(lerpAngleDegree(0, 90, 0)).toEqual(0);
+  });
+
+  it('should return b when weight is 1', () => {
+    expect(lerpAngleDegree(350, 10, 1)).toEqual(10);
+    expect(lerpAngleDegree(0, 90, 1)).toEqual(90);
+  });
+
+  it('should interpolate standard angles without crossing 0 boundary', () => {
+    expect(lerpAngleDegree(0, 90, 0.5)).toEqual(45);
+    expect(lerpAngleDegree(100, 200, 0.5)).toEqual(150);
+  });
+
+  it('should take the shortest arc across the 360/0 boundary (clockwise)', () => {
+    // 350 to 10 is +20 deg clockwise, midpoint is 0 / 360 -> 0
+    expect(lerpAngleDegree(350, 10, 0.5)).toEqual(0);
+    expect(lerpAngleDegree(350, 10, 0.25)).toEqual(355);
+    expect(lerpAngleDegree(350, 10, 0.75)).toEqual(5);
+  });
+
+  it('should take the shortest arc across the 360/0 boundary (counter-clockwise)', () => {
+    // 10 to 350 is -20 deg counter-clockwise, midpoint is 0
+    expect(lerpAngleDegree(10, 350, 0.5)).toEqual(0);
+    expect(lerpAngleDegree(10, 350, 0.25)).toEqual(5);
+    expect(lerpAngleDegree(10, 350, 0.75)).toEqual(355);
+  });
+
+  it('should handle inputs outside [0, 360) and normalize the output', () => {
+    expect(lerpAngleDegree(-10, 10, 0.5)).toEqual(0);
+    expect(lerpAngleDegree(710, 370, 0.5)).toEqual(0);
   });
 });
 
@@ -71,6 +108,16 @@ describe('linearInterpolate', () => {
       expect(linearInterpolate(3, [4, 5], 1, [2, 3], 1.5)).toEqual([2.5, 3.5]);
       expect(linearInterpolate(1, [2, 3], 3, [4, 5], 2.5)).toEqual([3.5, 4.5]);
       expect(linearInterpolate(3, [4, 5], 1, [2, 3], 2.5)).toEqual([3.5, 4.5]);
+    });
+
+    it('should support custom lerpFn for arrays', () => {
+      expect(linearInterpolate(1, [350, 10], 3, [10, 350], 2, lerpAngleDegree)).toEqual([0, 0]);
+    });
+  });
+
+  describe('custom lerpFn', () => {
+    it('should support lerpAngleDegree for scalar values', () => {
+      expect(linearInterpolate(1, 350, 3, 10, 2, lerpAngleDegree)).toEqual(0);
     });
   });
 });
@@ -124,6 +171,16 @@ describe('sampleAt', () => {
     const ys = [10, 20, 30, 40];
     expect(sampleAt(xs, ys, 0)).toEqual(0);
     expect(sampleAt(xs, ys, 5)).toEqual(50);
+  });
+
+  it('should interpolate angles with lerpAngleDegree over time on 2D arrays (e.g. windDirByTime)', () => {
+    const timesMs = [1000, 2000];
+    // Level 1: 350 -> 10 (midpoint 0), Level 2: 10 -> 350 (midpoint 0)
+    const windDirByTime = [
+      [350, 10],
+      [10, 350],
+    ];
+    expect(sampleAt(timesMs, windDirByTime, 1500, lerpAngleDegree)).toEqual([0, 0]);
   });
 });
 

--- a/libs/windy-sounding/src/util/math.ts
+++ b/libs/windy-sounding/src/util/math.ts
@@ -1,4 +1,9 @@
 /**
+ * Function type for linearly interpolating between two numeric values with a given weight.
+ */
+export type LerpFn = (v0: number, v1: number, weight: number) => number;
+
+/**
  * Linearly interpolates between two values or arrays of values.
  *
  * When ys are arrays they must have the same length.
@@ -8,6 +13,7 @@
  * @param x2 - The x-coordinate of the second point.
  * @param y2 - The y-coordinate or array of y-coordinates of the second point.
  * @param x - The x-coordinate at which to interpolate.
+ * @param lerpFn - Optional custom interpolation function (defaults to `lerp`).
  * @returns The interpolated value or array of values.
  *
  * @example
@@ -16,14 +22,22 @@
  * linearInterpolate(0, [10, 20], 10, [30, 40], 5); // [20, 30]
  * ```
  */
-export function linearInterpolate(x1: number, y1: number, x2: number, y2: number, x: number): number;
-export function linearInterpolate(x1: number, y1: number[], x2: number, y2: number[], x: number): number[];
+export function linearInterpolate(x1: number, y1: number, x2: number, y2: number, x: number, lerpFn?: LerpFn): number;
+export function linearInterpolate(
+  x1: number,
+  y1: number[],
+  x2: number,
+  y2: number[],
+  x: number,
+  lerpFn?: LerpFn,
+): number[];
 export function linearInterpolate(
   x1: number,
   y1: number | number[],
   x2: number,
   y2: number | number[],
   x: number,
+  lerpFn: LerpFn = lerp,
 ): number | number[] {
   if (x1 == x2) {
     return y1;
@@ -37,13 +51,13 @@ export function linearInterpolate(
     const len = Math.min(y1.length, y2.length);
     const ys: number[] = [];
     for (let i = 0; i < len; i++) {
-      ys.push(lerp(y1[i], y2[i], w));
+      ys.push(lerpFn(y1[i], y2[i], w));
     }
     return ys;
   }
 
   if (!isArrayY1 && !isArrayY2) {
-    return lerp(y1, y2, w);
+    return lerpFn(y1, y2, w);
   }
 
   throw new Error('Invalid arguments');
@@ -55,6 +69,7 @@ export function linearInterpolate(
  * @param xs - The x-coordinates of the data points. Must be sorted in ascending or descending order.
  * @param ys - The y-coordinates or arrays of y-coordinates of the data points. Must have the same length as `xs`.
  * @param targetXs - The x-coordinate or array of x-coordinates at which to sample.
+ * @param lerpFn - Optional custom interpolation function (defaults to `lerp`).
  * @returns The sampled value or array of values.
  *
  * @example
@@ -65,14 +80,15 @@ export function linearInterpolate(
  * sampleAt(xs, ys, [5, 15]); // [15, 25]
  * ```
  */
-export function sampleAt(xs: number[], ys: number[], targetXs: number): number;
-export function sampleAt(xs: number[], ys: number[][], targetXs: number): number[];
-export function sampleAt(xs: number[], ys: number[], targetXs: number[]): number[];
-export function sampleAt(xs: number[], ys: number[][], targetXs: number[]): number[][];
+export function sampleAt(xs: number[], ys: number[], targetXs: number, lerpFn?: LerpFn): number;
+export function sampleAt(xs: number[], ys: number[][], targetXs: number, lerpFn?: LerpFn): number[];
+export function sampleAt(xs: number[], ys: number[], targetXs: number[], lerpFn?: LerpFn): number[];
+export function sampleAt(xs: number[], ys: number[][], targetXs: number[], lerpFn?: LerpFn): number[][];
 export function sampleAt(
   xs: number[],
   ys: number[] | number[][],
   targetXs: number | number[],
+  lerpFn: LerpFn = lerp,
 ): number | number[] | number[][] {
   const descOrder = xs[0] > xs[1];
   const xsIsArray = Array.isArray(targetXs);
@@ -85,7 +101,7 @@ export function sampleAt(
       index = 1;
     }
     // y1 and y2 can be number | number[] but TS doesn't seem to understand they have the same type.
-    return linearInterpolate(xs[index - 1], ys[index - 1] as number, xs[index], ys[index] as number, tx);
+    return linearInterpolate(xs[index - 1], ys[index - 1] as number, xs[index], ys[index] as number, tx, lerpFn);
   });
   return xsIsArray ? values : values[0];
 }
@@ -280,6 +296,32 @@ export function svgPath(
  */
 export function lerp(v0: number, v1: number, weight: number): number {
   return v0 + weight * (v1 - v0);
+}
+
+/**
+ * Linearly interpolates between two angles in degrees along the shortest angular distance (shortest arc)
+ *
+ * Notes:
+ * - This function handles wrapping around 360 degrees.
+ * - The return value is normalized to the range [0, 360).
+ * *
+ * @param a - Starting angle in degrees.
+ * @param b - Ending angle in degrees.
+ * @param weight - Interpolation weight, where 0 returns `a` and 1 returns `b`.
+ * @returns The interpolated angle in degrees, normalized to [0, 360).
+ */
+export function lerpAngleDegree(a: number, b: number, weight: number): number {
+  // Difference between the target and start angles in the range (-360, 360).
+  const rawDiff = (b - a) % 360;
+
+  // Shortest arc in the range [-180, 180).
+  const wrappedDiff0To360 = (rawDiff + 540) % 360;
+  const shortestArcDelta = wrappedDiff0To360 - 180;
+
+  const interpolatedAngle = a + shortestArcDelta * weight;
+
+  // Normalize the interpolated angle to [0, 360).
+  return ((interpolatedAngle % 360) + 360) % 360;
 }
 
 /**

--- a/libs/windy-sounding/src/util/utils.test.ts
+++ b/libs/windy-sounding/src/util/utils.test.ts
@@ -6,6 +6,7 @@ import {
   getFavLabel,
   getSupportedModelName,
   isSupportedModelName,
+  latLon2Str,
   METEOBLUE_AI_MODEL,
 } from './utils';
 
@@ -79,6 +80,18 @@ describe('utils', () => {
       const formatted = formatTimestamp(ts);
       expect(typeof formatted).toBe('string');
       expect(formatted.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('latLon2Str', () => {
+    it('should convert lat/lon to string using W.utils.latLon2str', () => {
+      (globalThis as any).W = {
+        utils: {
+          latLon2str: vi.fn().mockImplementation(({ lat, lon }: any) => `${lat},${lon}`),
+        },
+      };
+      expect(latLon2Str({ lat: 45.83, lon: 6.86 })).toBe('45.83,6.86');
+      expect(latLon2Str({ lat: '45.83', lon: '6.86' })).toBe('45.83,6.86');
     });
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Fix windy plugin location handling and wind-direction interpolation while improving related utility coverage.

Bug Fixes:
- Correct wind-direction interpolation across the 360°/0° boundary by using shortest-arc angle interpolation.
- Prevent creation or movement of the map marker for the default 0°, 0° location.
- Ensure favorite locations render with stable React keys and continue selecting correctly.
- Stop updating the selected forecast location automatically after map movement.

Enhancements:
- Extend interpolation and sampling utilities to support custom interpolation functions, including normalized shortest-arc degree interpolation.
- Add coverage for angle interpolation, custom sampling, and favorite-location formatting.

Build:
- Bump the windy sounding plugin package version to 5.0.4.

Tests:
- Add tests covering angular interpolation, custom interpolation for scalar and array values, time-based wind-direction sampling, and latitude/longitude formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wind-direction interpolation for smoother, more accurate forecast values, including correct handling across the 0°/360° boundary.
  * Favorites selection on mobile now closes the location options panel automatically.

* **Bug Fixes**
  * Prevented the map from automatically changing the selected location while panning.

* **Chores**
  * Updated the package version to 5.0.3.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->