### PR TITLE
windy-plugin: clouds

### DIFF
--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -11,6 +11,7 @@ export type SkewTProps = {
   height: number;
   yPointer: number | undefined;
   levels: number[];
+  cloudLevels: number[];
   temps: number[];
   dewPoints: number[];
   ghs: number[];
@@ -36,6 +37,7 @@ export function SkewT(props: SkewTProps) {
     width,
     height,
     levels,
+    cloudLevels,
     temps,
     ghs,
     dewPoints,
@@ -190,7 +192,7 @@ export function SkewT(props: SkewTProps) {
         <Clouds
           {...{
             width,
-            levels,
+            cloudLevels,
             clouds,
             pressureToPxScale,
             surfacePressure: pressureToGhScale.invert(surfaceElevation),
@@ -199,7 +201,7 @@ export function SkewT(props: SkewTProps) {
         />
       </g>
     ),
-    [width, levels, clouds, pressureToPxScale, pressureToGhScale, surfaceElevation, showUpperClouds],
+    [width, cloudLevels, clouds, pressureToPxScale, pressureToGhScale, surfaceElevation, showUpperClouds],
   );
 
   const linesElement = useMemo(
@@ -508,23 +510,29 @@ function AltitudeAxis({
 
 export type CloudsProp = {
   width: number;
-  levels: number[];
+  cloudLevels: number[];
   clouds: number[];
   pressureToPxScale: Scale;
   surfacePressure: number;
   showUpperClouds: boolean;
 };
 
-function Clouds({ width, levels, clouds, pressureToPxScale, surfacePressure, showUpperClouds }: CloudsProp) {
+function Clouds({ width, cloudLevels, clouds, pressureToPxScale, surfacePressure, showUpperClouds }: CloudsProp) {
+  if (cloudLevels.length === 0 || clouds.length === 0) {
+    return null;
+  }
   const rects = [];
-  const pressureToCloudScale = math.scaleLinear(levels, clouds);
+  const pressureToCloudScale = math.scaleLog(cloudLevels, clouds);
 
   let y = 0;
 
   if (showUpperClouds) {
     y = 30;
     const upperPressure = pressureToPxScale.invert(y);
-    const upperCoverMax = Math.max(0, ...levels.map((level, i) => (level <= upperPressure ? clouds[i] ?? 0 : 0)));
+    const upperCoverMax = Math.max(
+      0,
+      ...cloudLevels.map((level, i) => (level <= upperPressure ? clouds[i] ?? 0 : 0)),
+    );
 
     if (upperCoverMax >= 5) {
       const opacity = (upperCoverMax / 100) * 0.75;

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -517,63 +517,85 @@ export type CloudsProp = {
   showUpperClouds: boolean;
 };
 
+const CLOUD_COLOR = '#666';
+const MIN_UPPER_CLOUD_COVER = 5;
+const MAX_OPACITY = 0.75;
+
+/**
+ * Calculate the opacity of a cloud based on its cloud cover.
+ * @param cloudCover The cloud cover, as a percentage.
+ * @returns The opacity of the cloud, as a string between 0.00 and MAX_OPACITY with 2 decimals precision.
+ */
+function cloudOpacity(cloudCover: number): string {
+  return ((cloudCover / 100) * MAX_OPACITY).toFixed(2);
+}
+
 function Clouds({ width, cloudLevels, clouds, pressureToPxScale, surfacePressure, showUpperClouds }: CloudsProp) {
   if (cloudLevels.length === 0 || clouds.length === 0) {
     return null;
   }
-  const rects = [];
+  const elements = [];
   const pressureToCloudScale = math.scaleLog(cloudLevels, clouds);
 
-  let y = 0;
+  let yStart = 0;
 
   if (showUpperClouds) {
-    y = 30;
-    const upperPressure = pressureToPxScale.invert(y);
-    const upperCoverMax = Math.max(
-      0,
-      ...cloudLevels.map((level, i) => (level <= upperPressure ? clouds[i] ?? 0 : 0)),
-    );
+    yStart = 30;
+    const upperPressure = pressureToPxScale.invert(yStart);
+    const upperCoverMax = Math.max(0, ...cloudLevels.map((level, i) => (level <= upperPressure ? clouds[i] ?? 0 : 0)));
 
-    if (upperCoverMax >= 5) {
-      const opacity = (upperCoverMax / 100) * 0.75;
-      rects.push(
-        <Cloud key="upper" y={0} width={width} height={30} opacity={opacity} />,
-        <text className="tick" y={30 - 12} x={width - 28} textAnchor="end">
+    if (upperCoverMax >= MIN_UPPER_CLOUD_COVER) {
+      elements.push(
+        <rect key="upper" y={0} width={width} height={30} fill={CLOUD_COLOR} opacity={cloudOpacity(upperCoverMax)} />,
+        <text key="upper-text" className="tick" y={30 - 12} x={width - 28} textAnchor="end">
           Upper
         </text>,
-        <Cirrus x={width - 20} y={10} scale={0.4}></Cirrus>,
-        <line y1="30" y2="30" x2={width} className="boundary" />,
+        <Cirrus key="upper-cirrus" x={width - 20} y={10} scale={0.4} />,
+        <line key="upper-line" y1="30" y2="30" x2={width} className="boundary" />,
       );
     }
   }
 
-  // Then respect the y scale
-  const surfaceY = pressureToPxScale(surfacePressure);
-  while (y < surfaceY) {
-    const startY = y;
-    const cloudPct = Math.max(0, Math.min(100, pressureToCloudScale(pressureToPxScale.invert(y))));
-    let layerHeight = 1;
-    while (y++ < surfaceY) {
-      const nextPct = Math.max(0, Math.min(100, pressureToCloudScale(pressureToPxScale.invert(y))));
-      if (Math.abs(nextPct - cloudPct) > 2 || nextPct >= 5 !== cloudPct >= 5) {
-        break;
-      }
-      layerHeight++;
-    }
-    if (cloudPct >= 5) {
-      const opacity = (cloudPct / 100) * 0.75;
-      rects.push(<Cloud key={startY} y={startY} width={width} height={layerHeight} opacity={opacity} />);
+  // Render cloud column using a linear gradient with stops at each pressure level.
+  const surfaceY = Math.round(pressureToPxScale(surfacePressure));
+  const columnHeight = surfaceY - yStart;
+
+  if (columnHeight > 0) {
+    const intermediatePoints = cloudLevels
+      .map((pressure) => ({ pressure, y: pressureToPxScale(pressure) }))
+      .filter(({ y }) => y >= yStart + 1 && y <= surfaceY - 1)
+      .sort((a, b) => a.y - b.y);
+
+    const columnPoints = [
+      { pressure: pressureToPxScale.invert(yStart), y: yStart },
+      ...intermediatePoints,
+      { pressure: surfacePressure, y: surfaceY },
+    ];
+
+    const stops = columnPoints.map(({ pressure, y }) => {
+      const cloudCover = Math.max(0, Math.min(100, pressureToCloudScale(pressure)));
+      return {
+        offset: (y - yStart) / columnHeight,
+        opacity: cloudOpacity(cloudCover),
+      };
+    });
+
+    // Only render the cloud rectangle if there is visible cloud cover
+    if (stops.some((s) => s.opacity > 0)) {
+      elements.push(
+        <defs key="cloud-gradient-defs">
+          <linearGradient id="cloud-gradient" x1="0" y1="0" x2="0" y2="100%">
+            {stops.map((stop, idx) => (
+              <stop key={idx} offset={stop.offset.toFixed(3)} stopColor={CLOUD_COLOR} stopOpacity={stop.opacity} />
+            ))}
+          </linearGradient>
+        </defs>,
+        <rect key="cloud-column" y={yStart} width={width} height={columnHeight} fill="url(#cloud-gradient)" />,
+      );
     }
   }
 
-  return <g>{rects}</g>;
-}
-
-function Cloud({ y, height, width, opacity }: { y: number; height: number; width: number; opacity: number }) {
-  if (opacity <= 0) {
-    return;
-  }
-  return <rect {...{ y, height, width }} fill={`rgba(100, 100, 100, ${opacity})`} />;
+  return <g>{elements}</g>;
 }
 
 function Cirrus({ x, y, scale }: { x: number; y: number; scale: number }) {

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -347,7 +347,7 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
 
       // Only update the active map level for overlays that support multiple altitude levels
       // (e.g. wind, temp) to avoid unnecessary or invalid level changes on surface-only layers (e.g. rain, radar).
-      const overlay = W.store.get('overlay') as keyof typeof W.overlays;
+      const overlay: keyof typeof W.overlays = W.store.get('overlay');
       const supportsLevels = W.overlays[overlay].hasMoreLevels;
       const availLevels = W.store.get('availLevels');
       if (supportsLevels && availLevels.length > 1) {
@@ -433,6 +433,7 @@ const ConnectedSkewT = memo(function ConnectedSkewT(props: ChildGraphProps) {
 
     return {
       levels: periodValues.levels,
+      cloudLevels: periodValues.cloudLevels,
       temps: timeValues.temp,
       dewPoints: timeValues.dewPoint,
       ghs: timeValues.gh,

--- a/libs/windy-sounding/src/redux/forecast-slice.ts
+++ b/libs/windy-sounding/src/redux/forecast-slice.ts
@@ -29,26 +29,40 @@ export enum FetchStatus {
 }
 
 // Those properties varies with the altitude level.
-const _levelProps = ['temp', 'dewPoint', 'gh', 'wind', 'windDir', 'rh', 'cloud'] as const;
+// All are defined at the same levels (the `PeriodValue.levels` array).
+const _levelProps = ['temp', 'dewPoint', 'gh', 'wind', 'windDir', 'rh'] as const;
 type LevelProp = (typeof _levelProps)[number];
 type LevelPropByTime = `${LevelProp}ByTime`;
+
+// Those properties varies with the cloud altitude level.
+// All are defined at the same levels (the `PeriodValue.cloudLevels` array).
+// Note that `PeriodValue.levels` and `PeriodValue.cloudLevels` can have different sizes/values.
+const _cloudLevelProps = ['cloud'] as const;
+type CloudLevelProp = (typeof _cloudLevelProps)[number];
+type CloudLevelPropByTime = `${CloudLevelProp}ByTime`;
 
 // Those properties do not vary with altitude.
 const _sfcProps = ['rainMm', 'seaLevelPressure'] as const;
 type SfcProps = (typeof _sfcProps)[number];
 type SfcPropsByTime = `${SfcProps}ByTime`;
 
-type TimeValue = Record<LevelProp, number[]> & Record<SfcProps, number>;
+// Values for a given time step.
+type TimeValue = Record<LevelProp | CloudLevelProp, number[]> & Record<SfcProps, number>;
 
 type ForecastType = WeatherDataPayload2<DataHash2>;
 
+// Values aggregated over all time steps (e.g. max/min over time)
 export type PeriodValue = {
   maxTemp: number;
   minTemp: number;
   maxSeaLevelPressure: number;
+  // Levels for `LevelProp`
   levels: number[];
+  // Levels for `CloudLevelProp`
+  cloudLevels: number[];
   timesMs: number[];
 } & Record<LevelPropByTime, number[][]> & // By time then by level
+  Record<CloudLevelPropByTime, number[][]> & // By time then by cloud level
   // By time only
   Record<SfcPropsByTime, number[]>;
 
@@ -244,7 +258,7 @@ function isWindyDataCached(state: ForecastState, key: string) {
  */
 function extractSoundingParamByLevel(
   sounding: SoundingDataHash2,
-  paramName: LevelProp,
+  paramName: LevelProp | CloudLevelProp,
   levels: number[],
   tsIndex: number,
 ): number[] {
@@ -282,7 +296,7 @@ function extractSoundingParamByLevel(
         value = sounding[`windDir-${levelKey}`]?.[tsIndex];
         break;
       case 'cloud':
-        value = sounding[`cloud-${levelKey}`]?.[tsIndex] ?? 0;
+        value = sounding[`cloud-${levelKey}`]?.[tsIndex];
         break;
     }
 
@@ -303,6 +317,7 @@ function computePeriodValues(
     fetchStatus: FetchStatus.Loaded;
   },
   levels: number[],
+  cloudLevels: number[],
 ): PeriodValue {
   if (!windyData.forecast.sounding?.ts) {
     throw new Error('Invalid forecast data: No sounding timestamps found.');
@@ -315,7 +330,9 @@ function computePeriodValues(
   let minTemp: number = Number.MAX_VALUE;
   let maxSeaLevelPressure: number = Number.MIN_VALUE;
 
-  const values: Record<LevelPropByTime, number[][]> & Record<SfcPropsByTime, number[]> = {
+  const values: Record<LevelPropByTime, number[][]> &
+    Record<CloudLevelPropByTime, number[][]> &
+    Record<SfcPropsByTime, number[]> = {
     dewPointByTime: [],
     ghByTime: [],
     rhByTime: [],
@@ -340,7 +357,7 @@ function computePeriodValues(
     values.rhByTime.push(extractSoundingParamByLevel(soundingData, 'rh', levels, tsIndex));
     values.windByTime.push(extractSoundingParamByLevel(soundingData, 'wind', levels, tsIndex));
     values.windDirByTime.push(extractSoundingParamByLevel(soundingData, 'windDir', levels, tsIndex));
-    values.cloudByTime.push(extractSoundingParamByLevel(soundingData, 'cloud', levels, tsIndex));
+    values.cloudByTime.push(extractSoundingParamByLevel(soundingData, 'cloud', cloudLevels, tsIndex));
     values.rainMmByTime.push(sampleAt(soundingTimeMs, windyData.forecast.data.precipAmount, timeMs));
     values.seaLevelPressureByTime.push(Math.round(seaLevelPressure));
   }
@@ -348,6 +365,7 @@ function computePeriodValues(
   return {
     timesMs: soundingTimeMs,
     levels,
+    cloudLevels,
     maxTemp,
     minTemp,
     maxSeaLevelPressure,
@@ -454,6 +472,25 @@ export const selDescendingLevels = createSelector(selLoadedWindyDataOrThrow, (wi
   );
 });
 
+export const selCloudDescendingLevels = createSelector(selLoadedWindyDataOrThrow, (windyData): number[] => {
+  const sounding = windyData.forecast.sounding;
+  if (!sounding?.ts) {
+    return [];
+  }
+  const numTimestamps = sounding.ts.length;
+  return (
+    Object.keys(sounding)
+      .filter((key: string) => key.startsWith('cloud-') && key.endsWith('h'))
+      // Only keep levels with non-null values for all timestamps
+      .filter((key: string) => {
+        const values = (sounding as Record<string, unknown>)[key];
+        return Array.isArray(values) && values.length >= numTimestamps && values.every((v) => v != null);
+      })
+      .map((key: string) => parseInt(key.slice(6, -1), 10))
+      .sort((a: number, b: number) => b - a)
+  );
+});
+
 export const selMaxModelPressure = createSelector(
   selDescendingLevels,
   (descendingLevels): number => descendingLevels[0],
@@ -467,7 +504,8 @@ export const selMinModelPressure = createSelector(
 export const selPeriodValues = createSelector(
   selLoadedWindyDataOrThrow,
   selDescendingLevels,
-  (windyData, levels): PeriodValue => computePeriodValues(windyData, levels),
+  selCloudDescendingLevels,
+  (windyData, levels, cloudLevels): PeriodValue => computePeriodValues(windyData, levels, cloudLevels),
 );
 
 export const selMaxPeriodTemp = createSelector(selPeriodValues, (periodValues): number => periodValues.maxTemp);


### PR DESCRIPTION
## Summary by Sourcery

Support cloud-specific sounding levels and display cloud coverage more accurately on Skew-T charts.

New Features:
- Render cloud cover on sounding charts using cloud-specific altitude levels and opacity gradients.
- Select and preserve cloud levels independently from other sounding parameters.

Bug Fixes:
- Correct cloud data extraction so missing cloud values are not treated as valid zero coverage.

Enhancements:
- Separate cloud-level data from standard sounding levels throughout forecast state and chart rendering.
- Improve cloud visualization with upper-cloud indicators and smoothly varying coverage across pressure levels.

Build:
- Bump the windy-sounding package version to 5.0.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Skew-T cloud visualization with smoother gradients and more accurate cloud-layer placement.
  * Improved rendering of upper-level clouds and cloud opacity.
  * Cloud data is now handled on its own pressure-level scale for clearer atmospheric profiles.

* **Bug Fixes**
  * Fixed cloud information being mapped to the chart’s general pressure levels, improving displayed sounding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->