### PR TITLE
Cumulus icons

### DIFF
--- a/libs/windy-sounding/README.md
+++ b/libs/windy-sounding/README.md
@@ -57,7 +57,7 @@ The procedure is the same as installing it on a computer.
 - The blue line shows the dewpoint,
 - The red line shows air temperature,
 - The green line shows the temperature of an ascending parcel,
-- The hatched area across the graph shows the convective layer (cumulus clouds),
+- The cumulus clouds across the graph show the convective layer,
 - The left area shows clouds (excluding cumulus),
 - The top-most area show upper level clouds (i.e. up to ~15km),
 - The wind graph shows wind from 0-30km/h in the left part (white background) and from 30 to max speed in right part (red background),

--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/parcel.tsx
+++ b/libs/windy-sounding/src/components/parcel.tsx
@@ -8,36 +8,111 @@ export type ParcelProps = {
   formatAltitude: (altitude: number) => number;
 };
 
+export const CUMULUS_PATH =
+  'M26 24H6a4 4 0 0 1-1-7.9A7.2 7.2 0 0 1 5 15a7 7 0 0 1 13.7-2 4.5 4.5 0 0 1 2.8-1c2.3 0 4.2 1.8 4.5 4a4 4 0 0 1 0 8z';
+
+// Small/medium clouds that drift slowly in the background
+const CUMULUS_SMALL_CLOUDS = [
+  { x: 55, y: 118, scale: 0.95 },
+  { x: 108, y: 82, scale: 1.1 },
+  { x: 158, y: 35, scale: 0.85 },
+  { x: 232, y: 132, scale: 0.9 },
+  { x: 282, y: 112, scale: 1.05 },
+  { x: 308, y: 38, scale: 0.8 },
+  { x: 318, y: 88, scale: 1.15 },
+];
+
+// Large clouds that drift faster in the foreground
+const CUMULUS_LARGE_CLOUDS = [
+  { x: 30, y: 48, scale: 1.25 },
+  { x: 82, y: 24, scale: 1.35 },
+  { x: 135, y: 140, scale: 1.3 },
+  { x: 184, y: 98, scale: 1.48 },
+  { x: 208, y: 22, scale: 1.22 },
+  { x: 258, y: 64, scale: 1.42 },
+  { x: 42, y: 142, scale: 1.35 },
+];
+
+export function CumulusPattern() {
+  return (
+    <>
+      <pattern id="cumulus-pattern-slow" patternUnits="userSpaceOnUse" width="340" height="160">
+        <g fill="lightyellow" stroke="#030104" strokeWidth="1" opacity="0.7">
+          {CUMULUS_SMALL_CLOUDS.map(({ x, y, scale }, i) => (
+            <path
+              key={i}
+              className="cumulus bg"
+              vectorEffect="non-scaling-stroke"
+              transform={`translate(${x}, ${y}) scale(${scale}) translate(-15, -15.5)`}
+              d={CUMULUS_PATH}
+            />
+          ))}
+        </g>
+      </pattern>
+      <pattern id="cumulus-pattern-fast" patternUnits="userSpaceOnUse" width="340" height="160">
+        <g fill="lightyellow" stroke="#030104" strokeWidth="1" opacity="0.7">
+          {CUMULUS_LARGE_CLOUDS.map(({ x, y, scale }, i) => (
+            <path
+              key={i}
+              className="cumulus bg"
+              vectorEffect="non-scaling-stroke"
+              transform={`translate(${x}, ${y}) scale(${scale}) translate(-15, -15.5)`}
+              d={CUMULUS_PATH}
+            />
+          ))}
+        </g>
+      </pattern>
+    </>
+  );
+}
+
 export function Parcel({ parcel, width, pathGenerator, pressureToPxScale, formatAltitude }: ParcelProps) {
   const parts = [];
   const thermalTopY = Math.round(pressureToPxScale(parcel.thermalTopPressure));
   if (parcel.cloudTopPressure) {
     const cloudTopY = Math.round(pressureToPxScale(parcel.cloudTopPressure));
+    const h = thermalTopY - cloudTopY;
     parts.push(
-      <rect y={cloudTopY} height={thermalTopY - cloudTopY} width={width} className="cumulus" />,
-      <Cumulus x={width} y={thermalTopY} />,
-      <line className="boundary" y1={cloudTopY} y2={cloudTopY} x2={width} />,
+      <g key="cumulus-layer" clipPath="url(#convective-clip)">
+        <defs>
+          <clipPath id="convective-clip">
+            <rect x={0} y={cloudTopY} width={width} height={h} />
+          </clipPath>
+        </defs>
+        <rect
+          className="cumulus-drift-slow"
+          x={-340}
+          y={cloudTopY}
+          width={width + 340}
+          height={h}
+          fill="url(#cumulus-pattern-slow)"
+        />
+        <rect
+          className="cumulus-drift-fast"
+          x={-340}
+          y={cloudTopY}
+          width={width + 340}
+          height={h}
+          fill="url(#cumulus-pattern-fast)"
+        />
+      </g>,
+      <Cumulus key="cumulus-icon" x={width} y={thermalTopY} />,
+      <line key="cloud-top-line" className="boundary" x1={0} y1={cloudTopY} x2={width} y2={cloudTopY} />,
     );
   }
   parts.push(
-    <line className="boundary" y1={thermalTopY} y2={thermalTopY} x2={width} />,
-    <text className="tick" y={thermalTopY + 4} x={width - 7}>
+    <line key="thermal-top-line" className="boundary" x1={0} y1={thermalTopY} x2={width} y2={thermalTopY} />,
+    <text key="elev-tick" className="tick" y={thermalTopY + 4} x={width - 7}>
       {formatAltitude(parcel.thermalTopElev)}
     </text>,
-    <path className="line" d={pathGenerator([...parcel.dry, ...parcel.wet])} />,
+    <path key="trajectory" className="line" d={pathGenerator([...parcel.dry, ...parcel.wet])} />,
+    <path key="isohume" className="isohume" d={pathGenerator(parcel.isohume)} />,
   );
-  parts.push(<path className="isohume" d={pathGenerator(parcel.isohume)} />);
 
   return <g className="parcel">{parts}</g>;
 }
 
 // https://www.flaticon.com/authors/yannick
 function Cumulus({ x, y }: { x: number; y: number }) {
-  return (
-    <path
-      className="cumulus"
-      transform={`translate(${x - 36}, ${y - 28})`}
-      d="M26 24H6a4 4 0 0 1-1-7.9A7.2 7.2 0 0 1 5 15a7 7 0 0 1 13.7-2 4.5 4.5 0 0 1 2.8-1c2.3 0 4.2 1.8 4.5 4a4 4 0 0 1 0 8z"
-    />
-  );
+  return <path className="cumulus" transform={`translate(${x - 36}, ${y - 28})`} d={CUMULUS_PATH} />;
 }

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -7,6 +7,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Favorites } from '../components/favorites';
 import { LoadingIndicator } from '../components/loading';
 import { Message } from '../components/message';
+import { CumulusPattern } from '../components/parcel';
 import { SkewT, type SkewTProps } from '../components/skewt';
 import { WindProfile } from '../components/wind-profile';
 import { pluginConfig } from '../config';
@@ -239,10 +240,7 @@ function SoundingDiagram({
   return (
     <svg {...{ height, width }}>
       <defs>
-        <pattern id="hatch" patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45 2 2)">
-          <rect width="8" height="8" fill="lightyellow" opacity="0.4" />
-          <path d="M 0,-1 L 0,11" stroke="gray" strokeWidth="1" />
-        </pattern>
+        <CumulusPattern />
         <filter id="outline" colorInterpolationFilters="sRGB">
           <feMorphology in="SourceAlpha" result="morph" operator="dilate" radius="2" />
           <feColorMatrix

--- a/libs/windy-sounding/src/styles.less
+++ b/libs/windy-sounding/src/styles.less
@@ -228,8 +228,38 @@
 
     .boundary {
       stroke: darkgray;
-      stroke-width: 0.5px;
+      stroke-width: 1px;
       shape-rendering: crispEdges;
+    }
+
+    path.cumulus {
+      stroke: #030104;
+      fill: lightyellow;
+      stroke-width: 2;
+      vector-effect: non-scaling-stroke;
+
+      &.bg {
+        stroke-width: 1;
+        opacity: 0.7;
+        vector-effect: non-scaling-stroke;
+      }
+    }
+
+    @keyframes cumulus-drift {
+      from {
+        transform: translate3d(0, 0, 0);
+      }
+      to {
+        transform: translate3d(340px, 0, 0);
+      }
+    }
+
+    .cumulus-drift-slow {
+      animation: cumulus-drift 80s linear infinite;
+    }
+
+    .cumulus-drift-fast {
+      animation: cumulus-drift 60s linear infinite;
     }
 
     &.skewt {
@@ -363,12 +393,11 @@
           stroke: #030104;
           fill: lightyellow;
           stroke-width: 2;
-        }
 
-        rect.cumulus {
-          opacity: 0.8;
-          fill: url(#hatch);
-          shape-rendering: crispEdges;
+          &.bg {
+            stroke-width: 1;
+            opacity: 0.7;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary by Sourcery

Visualize convective layers with animated cumulus clouds instead of hatched shading.

New Features:
- Replace the convective-layer hatch with animated cumulus cloud icons at multiple drift speeds.
- Add a reusable cumulus cloud pattern and retain a cloud icon at the thermal top of the parcel.

Enhancements:
- Improve sounding diagram boundary visibility and render parcel trajectory and isohume paths consistently.
- Update the user-facing README description to reflect the cumulus cloud visualization.

Documentation:
- Update the sounding chart documentation to describe cumulus clouds as the convective-layer indicator.

Chores:
- Bump the windy-sounding package version to 5.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added animated cumulus cloud layers to the sounding graph between cloud-top and thermal-top boundaries.
  - Added distinct slow- and fast-moving cloud patterns for improved visual context.
  - Displayed the isohume path alongside the parcel trajectory.

- **Style**
  - Replaced the previous hatched convective-layer background with cloud visuals.
  - Improved graph boundary visibility and refined cloud styling for clearer readability.
  - Updated documentation to reflect the new cumulus cloud visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->