### PR TITLE
minor changes in the windy-plugin

### DIFF
--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/components/favorites.tsx
+++ b/libs/windy-sounding/src/components/favorites.tsx
@@ -1,19 +1,27 @@
 import type { Fav, LatLon } from '@windy/interfaces';
 import { useState } from 'preact/hooks';
 
-import { round } from '../util/math';
 import { getAvailableModels, getFavLabel, latLon2Str } from '../util/utils';
 
 export type FavoriteProps = {
   favorites: Fav[];
   location: LatLon;
+  locationLabel: string;
   isMobile: boolean;
   onSelected: (location: LatLon) => void;
   onSelectModel?: (model: string) => void;
   modelName: string;
 };
 
-export function Favorites({ favorites, location, isMobile, onSelected, onSelectModel, modelName }: FavoriteProps) {
+export function Favorites({
+  favorites,
+  location,
+  locationLabel,
+  isMobile,
+  onSelected,
+  onSelectModel,
+  modelName,
+}: FavoriteProps) {
   const locationStr = latLon2Str(location);
   const [isModelExpanded, setIsModelExpanded] = useState(false);
   const [isLocationExpanded, setIsLocationExpanded] = useState(false);
@@ -37,19 +45,6 @@ export function Favorites({ favorites, location, isMobile, onSelected, onSelectM
   if (isMobile) {
     const models: string[] = getAvailableModels(location);
 
-    const { lat, lon } = location;
-
-    let currentFavorite = `${round(Math.abs(lat), 1)}${lat >= 0 ? 'N' : 'S'} ${round(Math.abs(lon), 1)}${
-      lon >= 0 ? 'E' : 'W'
-    }`;
-    for (const favorite of favorites) {
-      const favLocationStr = latLon2Str(favorite);
-      if (favLocationStr === locationStr) {
-        currentFavorite = getFavLabel(favorite);
-        break;
-      }
-    }
-
     return (
       <>
         <section id="wsp-favorite">
@@ -67,7 +62,7 @@ export function Favorites({ favorites, location, isMobile, onSelected, onSelectM
             data-icon-after="g"
             onClick={toggleLocationSelect}
           >
-            <small className="size-m">{currentFavorite}</small>
+            <small className="size-m">{locationLabel}</small>
           </div>
           <a style={{ margin: '0 10px 3px 5px' }} href="https://buymeacoffee.com/vic.b" target="_blank">
             ☕️

--- a/libs/windy-sounding/src/components/parcel.tsx
+++ b/libs/windy-sounding/src/components/parcel.tsx
@@ -80,7 +80,7 @@ export function Parcel({ parcel, width, pathGenerator, pressureToPxScale, format
           </clipPath>
         </defs>
         <rect
-          className="cumulus-drift-slow"
+          className="cumulus-drift slow"
           x={-340}
           y={cloudTopY}
           width={width + 340}
@@ -88,7 +88,7 @@ export function Parcel({ parcel, width, pathGenerator, pressureToPxScale, format
           fill="url(#cumulus-pattern-slow)"
         />
         <rect
-          className="cumulus-drift-fast"
+          className="cumulus-drift fast"
           x={-340}
           y={cloudTopY}
           width={width + 340}

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -14,7 +14,7 @@ import { pluginConfig } from '../config';
 import flyxcIcon from '../img/jumoplane.svg';
 import * as forecastSlice from '../redux/forecast-slice';
 import type { TimeStep } from '../redux/meta';
-import { centerMap, changeLocation, changeModel, updateTime } from '../redux/meta';
+import { centerMap, changeLocation, changeModel, updateLocationName, updateTime } from '../redux/meta';
 import * as pluginSlice from '../redux/plugin-slice';
 import { type AppDispatch, type RootState } from '../redux/store';
 import * as unitsSlice from '../redux/units-slice';
@@ -503,10 +503,18 @@ function ConnectedFavorites({ onSelected }: { onSelected: (location: LatLon) => 
     return {
       favorites: S.selFavorites(state),
       location: S.selLocation(state),
+      locationLabel: S.selLocationLabel(state),
       isMobile: W.rootScope.isMobileOrTablet,
       modelName: S.selModelName(state),
     };
   }, shallowEqual);
+
+  // Only fetch reverse-geocoded location names on mobile/tablet where it is used.
+  useEffect(() => {
+    if (props.isMobile) {
+      dispatch(updateLocationName(props.location));
+    }
+  }, [dispatch, props.isMobile, props.location]);
 
   return <Favorites {...{ ...props, onSelected, onSelectModel: selectModel }} />;
 }

--- a/libs/windy-sounding/src/env.d.ts
+++ b/libs/windy-sounding/src/env.d.ts
@@ -22,5 +22,7 @@ declare const W: {
   http: typeof import('@windy/client/http');
   user: typeof import('@windy/client/user');
   overlays: typeof import('@windy/client/overlays').default;
+  reverseName: typeof import('@windy/client/reverseName');
+  geolocation: typeof import('@windy/client/geolocation');
 };
 /* eslint-enable */

--- a/libs/windy-sounding/src/redux/meta.ts
+++ b/libs/windy-sounding/src/redux/meta.ts
@@ -11,6 +11,19 @@ import type { RootState } from './store';
 const { map: windyMap, markers } = W.map;
 const windyRootScope = W.rootScope;
 
+// Pending in-flight location name request that can be aborted when location changes.
+let inFlightLocationPromise: { abort: () => void } | undefined;
+
+/**
+ * Dispatches fetchLocationName to retrieve reverse-geocoded name, aborting any prior pending request.
+ */
+export const updateLocationName =
+  (location: LatLon): ThunkAction<void, RootState, unknown, UnknownAction> =>
+  (dispatch) => {
+    inFlightLocationPromise?.abort();
+    inFlightLocationPromise = dispatch(pluginSlice.fetchLocationName(location));
+  };
+
 // Cross slice thunks
 
 export type TimeStep = {
@@ -169,6 +182,10 @@ export function addSubscription(fn: Subscription) {
 }
 
 export function cancelAllSubscriptions() {
+  if (inFlightLocationPromise) {
+    inFlightLocationPromise.abort();
+    inFlightLocationPromise = undefined;
+  }
   for (const fn of subscriptions) {
     fn();
   }

--- a/libs/windy-sounding/src/redux/plugin-slice.ts
+++ b/libs/windy-sounding/src/redux/plugin-slice.ts
@@ -1,8 +1,8 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
 import type { Fav } from '@windy/favs';
 import type { LatLon } from '@windy/interfaces';
 
-import { getFavLabel, getSupportedModelName } from '../util/utils';
+import { getFavLabel, getSupportedModelName, latLon2Str } from '../util/utils';
 import type { RootState } from './store';
 
 const windyStore = W.store;
@@ -22,6 +22,7 @@ type PluginState = {
   width: number;
   height: number;
   location: LatLon;
+  locationName: string | null;
   status: PluginStatus;
 };
 
@@ -31,10 +32,51 @@ const initialState: PluginState = {
   width: 100,
   height: 100,
   location: { lat: 0, lon: 0 },
+  locationName: null,
   modelName: 'ecmwf',
   timeMs: windyStore.get('timestamp'),
   status: PluginStatus.Idle,
 };
+
+/**
+ * Asynchronously fetches a reverse-geocoded place name from Windy for non-favorite locations.
+ * Uses a 200ms debounce delay cancellable via AbortSignal to avoid flooding requests during map dragging.
+ */
+export const fetchLocationName = createAsyncThunk<string | null, LatLon, { state: RootState }>(
+  'plugin/fetchLocationName',
+  async (location: LatLon, { signal }) => {
+    // Debounce delay cancellable via AbortSignal
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, 200);
+      signal.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(new DOMException('Aborted', 'AbortError'));
+      });
+    });
+
+    const lat = Number(location.lat);
+    const lon = Number(location.lon);
+    if (isNaN(lat) || isNaN(lon)) {
+      return null;
+    }
+
+    const result = await W.reverseName.get({ lat, lon }, 10);
+
+    if (signal.aborted) {
+      return null;
+    }
+
+    return result?.nameValid ? result.name.trim() : W.geolocation.getFallbackName(lat, lon);
+  },
+  {
+    condition: (location, { getState }) => {
+      const state = getState();
+      const matchingFavorite = selMatchingFavorite(state);
+      // Skip lookup if already at a favorite or at initial dummy coordinates.
+      return !matchingFavorite && (location.lat !== 0 || location.lon !== 0);
+    },
+  },
+);
 
 export const slice = createSlice({
   name: 'plugin',
@@ -60,11 +102,31 @@ export const slice = createSlice({
       state.height = action.payload;
     },
     setLocation: (state, action: { payload: LatLon }) => {
-      state.location = action.payload;
+      if (state.location.lat !== action.payload.lat || state.location.lon !== action.payload.lon) {
+        state.location = action.payload;
+        state.locationName = null;
+      }
+    },
+    setLocationName: (state, action: { payload: string | null }) => {
+      state.locationName = action.payload;
     },
     setStatus: (state, action: { payload: PluginStatus }) => {
       state.status = action.payload;
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchLocationName.pending, (state) => {
+      state.locationName = null;
+    });
+    builder.addCase(fetchLocationName.fulfilled, (state, action) => {
+      state.locationName = action.payload;
+    });
+    builder.addCase(fetchLocationName.rejected, (state, action) => {
+      // Avoid clearing place name if skipped by condition or cancelled
+      if (!action.meta.condition && !action.meta.aborted) {
+        state.locationName = null;
+      }
+    });
   },
 });
 
@@ -74,10 +136,47 @@ export const selModelName = (state: RootState): string => state[slice.name].mode
 export const selTimeMs = (state: RootState): number => state[slice.name].timeMs;
 export const selIsZoomedIn = (state: RootState): boolean => state[slice.name].isZoomedIn;
 export const selLocation = (state: RootState): LatLon => state[slice.name].location;
+export const selLocationName = (state: RootState): string | null => state[slice.name].locationName;
 export const selFavorites = (state: RootState): Fav[] => state[slice.name].favorites;
 export const selStatus = (state: RootState): PluginStatus => state[slice.name].status;
 
-export const { setIsZoomedIn, setFavorites, setModelName, setTimeMs, setWidth, setHeight, setLocation, setStatus } =
-  slice.actions;
+/**
+ * Returns the user favorite matching the current location (if any).
+ */
+export const selMatchingFavorite = createSelector(
+  [selFavorites, selLocation],
+  (favorites, location): Fav | undefined => {
+    const locationStr = latLon2Str(location);
+    return favorites.find((fav) => latLon2Str(fav) === locationStr);
+  },
+);
+
+/**
+ * Computes the location label: matching favorite title > reverse-geocoded place name > GPS coordinates fallback.
+ */
+export const selLocationLabel = createSelector(
+  [selMatchingFavorite, selLocationName, selLocation],
+  (matchingFav, locationName, location): string => {
+    if (matchingFav) {
+      return getFavLabel(matchingFav);
+    }
+    if (locationName) {
+      return locationName;
+    }
+    return W.geolocation.getFallbackName(location.lat, location.lon);
+  },
+);
+
+export const {
+  setIsZoomedIn,
+  setFavorites,
+  setModelName,
+  setTimeMs,
+  setWidth,
+  setHeight,
+  setLocation,
+  setLocationName,
+  setStatus,
+} = slice.actions;
 
 export const { reducer } = slice;

--- a/libs/windy-sounding/src/styles.less
+++ b/libs/windy-sounding/src/styles.less
@@ -254,12 +254,17 @@
       }
     }
 
-    .cumulus-drift-slow {
-      animation: cumulus-drift 80s linear infinite;
-    }
+    .cumulus-drift {
+      animation: cumulus-drift linear infinite;
+      opacity: 0.5;
 
-    .cumulus-drift-fast {
-      animation: cumulus-drift 60s linear infinite;
+      &.slow {
+        animation-duration: 80s;
+      }
+
+      &.fast {
+        animation-duration: 60s;
+      }
     }
 
     &.skewt {


### PR DESCRIPTION
## Summary by Sourcery

Improve mobile location labeling and streamline cloud drift presentation in the sounding plugin.

New Features:
- Display reverse-geocoded location names on mobile and tablet, while preserving favorite labels and coordinate fallbacks.

Bug Fixes:
- Prevent stale or unnecessary location-name lookups when locations change, requests are cancelled, or the current location is a favorite.

Enhancements:
- Refine cumulus cloud drift styling with shared animation behavior and configurable slow and fast speeds.

Build:
- Bump the windy-sounding package version to 5.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mobile location selectors now display clear place names for the selected location.
  - Location names update automatically when selecting a non-favorite location.

- **Bug Fixes**
  - Improved handling when rapidly changing locations to prevent outdated names from appearing.
  - Refined cloud drift animation styling for more consistent visual behavior.

- **Chores**
  - Updated the package version to 5.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->