### PR TITLE
fix(windy-plugin): switch layer level on ICAO levels

### DIFF
--- a/libs/windy-sounding/package.json
+++ b/libs/windy-sounding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-fxc-soundings",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "type": "module",
   "private": true,
   "description": "Alternative sounding graphs with custom features for PG/HG pilots.",

--- a/libs/windy-sounding/src/containers/containers.tsx
+++ b/libs/windy-sounding/src/containers/containers.tsx
@@ -361,7 +361,7 @@ function Graph({ width, height, skewTWidthPercent }: { width: number; height: nu
           .filter((level) => level.endsWith('h'))
           .map((level) => {
             const levelPressure = parseInt(level.slice(0, -1), 10);
-            return { level, elev: pressureToGhScale(levelPressure) };
+            return { level, elev: atm.getElevation(levelPressure) };
           });
 
         levelsWithElev.sort((a, b) => a.elev - b.elev);


### PR DESCRIPTION
## Summary by Sourcery

Fix ICAO-level layer switching by aligning pressure-level elevations with the atmospheric model.

Bug Fixes:
- Correct layer ordering for ICAO pressure levels by using atmospheric elevation calculations.

Chores:
- Bump the windy sounding plugin version to 5.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pressure-level altitude selection in graphs for more accurate elevation display.

* **Chores**
  * Updated the package version to 5.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->