### PR TITLE
InReach: error for LiveTrack URLs that are not supported

### DIFF
--- a/libs/common/src/lib/models.test.ts
+++ b/libs/common/src/lib/models.test.ts
@@ -86,8 +86,12 @@ describe('Validate Inreach account', () => {
       property: 'account',
     });
     expect(validator.message).toContain('LiveTrack is not supported');
-    expect(validator.message).toContain('share.garmin.com');
-    expect(validator.message).toContain('https://explore.garmin.com/Social');
+    expect(await validator.validate({ enabled: true, account: 'https://live.garmin.com.attacker.com/user' })).toEqual(
+      {
+        property: 'account',
+      },
+    );
+    expect(validator.message).toBe('This InReach URL is invalid');
 
     expect(await validator.validate({ enabled: true, account: 'invalid-url' })).toEqual({
       property: 'account',

--- a/libs/common/src/lib/models.test.ts
+++ b/libs/common/src/lib/models.test.ts
@@ -1,4 +1,5 @@
 import {
+  InreachAccountSyncValidator,
   validateFlymasterAccount,
   validateInreachAccount,
   validateMeshBirAccount,
@@ -72,6 +73,28 @@ describe('Validate Inreach account', () => {
     expect(validateInreachAccount('user')).toEqual(false);
     expect(validateInreachAccount('https://share.gmin.com/user')).toEqual(false);
     expect(validateInreachAccount('https://share.garmin/com/user')).toEqual(false);
+    expect(validateInreachAccount('https://live.garmin.com/session/123')).toEqual(false);
+    expect(validateInreachAccount('https://live.garmin.com/user')).toEqual(false);
+    expect(validateInreachAccount('live.garmin.com/user')).toEqual(false);
+  });
+
+  test('InreachAccountSyncValidator', async () => {
+    const validator = new InreachAccountSyncValidator();
+    expect(await validator.validate({ enabled: false, account: 'https://live.garmin.com/user' })).toBe(true);
+
+    expect(await validator.validate({ enabled: true, account: 'https://live.garmin.com/user' })).toEqual({
+      property: 'account',
+    });
+    expect(validator.message).toContain('LiveTrack is not supported');
+    expect(validator.message).toContain('share.garmin.com');
+    expect(validator.message).toContain('https://explore.garmin.com/Social');
+
+    expect(await validator.validate({ enabled: true, account: 'invalid-url' })).toEqual({
+      property: 'account',
+    });
+    expect(validator.message).toBe('This InReach URL is invalid');
+
+    expect(await validator.validate({ enabled: true, account: 'https://share.garmin.com/user' })).toBe(true);
   });
 });
 

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -113,7 +113,7 @@ export class TrackerFormModel extends ObjectModel<TrackerModel> {
 }
 
 // Validates a TrackerModel using a callback.
-class AccountSyncValidator implements Validator<TrackerModel> {
+export class AccountSyncValidator implements Validator<TrackerModel> {
   constructor(public message: string, public callback: (account: string) => string | false) {}
 
   async validate(tracker: TrackerModel) {
@@ -124,9 +124,36 @@ class AccountSyncValidator implements Validator<TrackerModel> {
   }
 }
 
+// Makes sure the account is not a LiveTrack URL and is a valid InReach URL.
+//
+// LiveTrack URLs on live.garmin.com are not supported; MapShare URLs on share.garmin.com must be used instead.
+// See https://support.garmin.com/en-US/?faq=2DeeJYxoOf9EUQ1jjCGCZA
+export class InreachAccountSyncValidator extends AccountSyncValidator {
+  constructor() {
+    super('This InReach URL is invalid', validateInreachAccount);
+  }
+
+  override async validate(tracker: TrackerModel) {
+    if (tracker.enabled) {
+      if (/live\.garmin\.com/i.test(tracker.account)) {
+        this.message =
+          'LiveTrack is not supported. ' +
+          'Use MapShare instead (URL starts with share.garmin.com). ' +
+          'Configure this at https://explore.garmin.com/Social';
+        return { property: 'account' };
+      }
+      this.message = 'This InReach URL is invalid';
+      if (this.callback(tracker.account) === false) {
+        return { property: 'account' };
+      }
+    }
+    return true;
+  }
+}
+
 // Validators used on both the client and server sides.
 export const trackerValidators: Readonly<Record<TrackerNames, AccountSyncValidator[]>> = {
-  inreach: [new AccountSyncValidator('This InReach URL is invalid', validateInreachAccount)],
+  inreach: [new InreachAccountSyncValidator()],
   spot: [new AccountSyncValidator('This Spot ID is invalid', validateSpotAccount)],
   skylines: [new AccountSyncValidator('This Skylines ID is invalid', validateSkylinesAccount)],
   flyme: [],
@@ -163,14 +190,23 @@ export function validateSkylinesAccount(id: string): string | false {
 // 'share' could also be 'eur.inreach', 'aur-share.inreach'.
 //
 // urls are transformed to the second form (with '/Feed/Share/').
+//
+// LiveTrack urls (on live.garmin.com) are not supported.
+// See https://support.garmin.com/en-US/?faq=2DeeJYxoOf9EUQ1jjCGCZA
 export function validateInreachAccount(url: string): string | false {
   url = url.trim();
+
+  // Reject LiveTrack urls (on live.garmin.com domain).
+  // See https://support.garmin.com/en-US/?faq=2DeeJYxoOf9EUQ1jjCGCZA
+  if (/live\.garmin\.com/i.test(url)) {
+    return false;
+  }
 
   // Insert '/Feed/Share' when missing.
   if (!/Feed\/Share/i.test(url)) {
     const lastSlash = url.lastIndexOf('/');
     if (lastSlash > -1) {
-      url = url.substring(0, lastSlash) + '/Feed/Share' + url.substr(lastSlash);
+      url = url.substring(0, lastSlash) + '/Feed/Share' + url.substring(lastSlash);
     }
   }
 

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -124,6 +124,16 @@ export class AccountSyncValidator implements Validator<TrackerModel> {
   }
 }
 
+// Returns whether the URL points to the live.garmin.com LiveTrack domain.
+function isLiveGarminUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url.includes('://') ? url : `https://${url}`);
+    return parsed.hostname.toLowerCase().endsWith('live.garmin.com');
+  } catch {
+    return false;
+  }
+}
+
 // Makes sure the account is not a LiveTrack URL and is a valid InReach URL.
 //
 // LiveTrack URLs on live.garmin.com are not supported; MapShare URLs on share.garmin.com must be used instead.
@@ -135,7 +145,7 @@ export class InreachAccountSyncValidator extends AccountSyncValidator {
 
   override async validate(tracker: TrackerModel) {
     if (tracker.enabled) {
-      if (/live\.garmin\.com/i.test(tracker.account)) {
+      if (isLiveGarminUrl(tracker.account)) {
         this.message =
           'LiveTrack is not supported. ' +
           'Use MapShare instead (URL starts with share.garmin.com). ' +
@@ -198,7 +208,7 @@ export function validateInreachAccount(url: string): string | false {
 
   // Reject LiveTrack urls (on live.garmin.com domain).
   // See https://support.garmin.com/en-US/?faq=2DeeJYxoOf9EUQ1jjCGCZA
-  if (/live\.garmin\.com/i.test(url)) {
+  if (isLiveGarminUrl(url)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve InReach account validation by rejecting unsupported LiveTrack URLs and guiding users toward MapShare URLs.

New Features:
- Reject unsupported Garmin LiveTrack URLs for enabled InReach accounts and direct users to configure a MapShare URL instead.

Bug Fixes:
- Prevent LiveTrack and lookalike live.garmin.com URLs from being accepted as valid InReach accounts.

Enhancements:
- Expose and specialize account synchronization validation for InReach URL-specific error messages.

Tests:
- Add coverage for unsupported LiveTrack URLs, invalid lookalike domains, disabled accounts, and valid MapShare URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved InReach account validation for unsupported `live.garmin.com` URLs, including session, user, and bare-host links.
  * Added clearer messages when LiveTrack links are unsupported.
  * Enhanced rejection of invalid and lookalike URLs.
  * Preserved support for valid `share.garmin.com` URLs.
  * Disabled InReach accounts can now pass validation without URL checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->