### PR TITLE
refactor(gce): migrate VMs to cloud-init away from konlet

### DIFF
--- a/apps/fetcher/README.md
+++ b/apps/fetcher/README.md
@@ -1,11 +1,80 @@
-## Deploy
+# FlyXC Fetcher
 
-nx deploy fetcher --prod
+Fetcher is a background service that continuously polls live tracking devices and updates datastore. It runs in a container on a Google Compute Engine VM using Container-Optimized OS (COS) and is managed via `systemd` and `cloud-init`.
 
-## Docker
+## Build & Deploy
 
-docker run -it gcr.io/fly-xc/fetcher bash
+To build the container image and restart the service on the running VM:
 
-## Update the image
+```bash
+pnpm nx deploy fetcher
+```
 
-gcloud compute instances update-container fetcher --container-image gcr.io/fly-xc/fetcher:latest
+## Infrastructure & VM Management
+
+### 1. Create or Update the Instance Template
+
+The instance template uses `cloud-config.yaml` to define the `systemd` service:
+
+```bash
+pnpm nx create-template fetcher
+```
+
+Equivalent `gcloud` command:
+
+```bash
+gcloud compute instance-templates delete fetcher-tmpl --quiet || true
+gcloud compute instance-templates create fetcher-tmpl \
+  --machine-type=e2-micro \
+  --image-family=cos-stable \
+  --image-project=cos-cloud \
+  --boot-disk-size=10GB \
+  --boot-disk-type=pd-balanced \
+  --scopes=cloud-platform \
+  --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true \
+  --metadata-from-file=user-data=apps/fetcher/cloud-config.yaml
+```
+
+### 2. Create the VM
+
+To spin up a new VM instance from the template:
+
+```bash
+pnpm nx create-vm fetcher
+```
+
+Equivalent `gcloud` command:
+
+```bash
+gcloud compute instances create fetcher \
+  --source-instance-template=fetcher-tmpl \
+  --zone=us-central1-a
+```
+
+### 3. Verify It's Running
+
+Wait ~30–60s after VM creation for COS to boot, pull the container image, and start the systemd service:
+
+```bash
+# Check systemd service status
+gcloud compute ssh fetcher --zone=us-central1-a --command="sudo systemctl status fetcher.service"
+
+# View live container logs
+gcloud compute ssh fetcher --zone=us-central1-a --command="docker logs -f fetcher"
+
+# View systemd journal logs on the VM
+gcloud compute ssh fetcher --zone=us-central1-a --command="sudo journalctl -u fetcher.service -f"
+```
+
+### 4. Useful Operations
+
+```bash
+# SSH into the VM
+gcloud compute ssh fetcher --zone=us-central1-a
+
+# Restart the service (pulls latest image and starts container)
+gcloud compute ssh fetcher --zone=us-central1-a --command="sudo systemctl restart fetcher.service"
+
+# Delete the VM instance
+gcloud compute instances delete fetcher --zone=us-central1-a --quiet
+```

--- a/apps/fetcher/cloud-config.yaml
+++ b/apps/fetcher/cloud-config.yaml
@@ -22,6 +22,9 @@ write_files:
       ExecStart=/usr/bin/docker run --name fetcher --rm us-docker.pkg.dev/fly-xc/docker/fetcher:latest
       ExecStop=/usr/bin/docker stop fetcher
 
+      [Install]
+      WantedBy=multi-user.target
+
 runcmd:
   - systemctl daemon-reload
-  - systemctl restart fetcher.service
+  - systemctl enable --now fetcher.service

--- a/apps/fetcher/cloud-config.yaml
+++ b/apps/fetcher/cloud-config.yaml
@@ -1,0 +1,27 @@
+#cloud-config
+
+write_files:
+  - path: /etc/systemd/system/fetcher.service
+    permissions: "0644"
+    owner: root
+    content: |
+      [Unit]
+      Description=FlyXC Fetcher Container
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      TimeoutStartSec=0
+      Restart=always
+      Environment="DOCKER_CONFIG=/var/lib/docker-config"
+      ExecStartPre=/bin/mkdir -p /var/lib/docker-config
+      ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries us-docker.pkg.dev
+      ExecStartPre=-/usr/bin/docker stop fetcher
+      ExecStartPre=-/usr/bin/docker rm fetcher
+      ExecStartPre=/usr/bin/docker pull us-docker.pkg.dev/fly-xc/docker/fetcher:latest
+      ExecStart=/usr/bin/docker run --name fetcher --rm us-docker.pkg.dev/fly-xc/docker/fetcher:latest
+      ExecStop=/usr/bin/docker stop fetcher
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl restart fetcher.service

--- a/apps/fetcher/project.json
+++ b/apps/fetcher/project.json
@@ -70,11 +70,23 @@
         "tags": ["us-docker.pkg.dev/fly-xc/docker/fetcher"]
       }
     },
+    "create-template": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "gcloud compute instance-templates delete fetcher-tmpl --quiet || true && gcloud compute instance-templates create fetcher-tmpl --machine-type=e2-micro --image-family=cos-stable --image-project=cos-cloud --boot-disk-size=10GB --boot-disk-type=pd-balanced --scopes=cloud-platform --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true --metadata-from-file=user-data=apps/fetcher/cloud-config.yaml"
+      }
+    },
+    "create-vm": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "gcloud compute instances create fetcher --source-instance-template=fetcher-tmpl --zone=us-central1-a"
+      }
+    },
     "deploy": {
       "executor": "nx:run-commands",
       "dependsOn": ["container"],
       "options": {
-        "command": "gcloud compute instances update-container fetcher --container-image=us-docker.pkg.dev/fly-xc/docker/fetcher"
+        "command": "gcloud compute ssh fetcher --zone=us-central1-a --command=\"sudo systemctl restart fetcher.service\""
       }
     }
   }

--- a/apps/proxy/README.md
+++ b/apps/proxy/README.md
@@ -1,0 +1,52 @@
+# FlyXC Proxy
+
+The Proxy service runs in a container on temporary Google Compute Engine VMs using Container-Optimized OS (COS). Proxy VMs are created and terminated dynamically by `fetcher` ([`apps/fetcher/src/app/trackers/proxies.ts`](file:///home/victor/code/flyXC/apps/fetcher/src/app/trackers/proxies.ts)) using the `proxy-tmpl` instance template.
+
+## Build & Deploy Image
+
+To build and push the container image to Artifact Registry:
+
+```bash
+pnpm nx container proxy
+```
+
+## Instance Template Management
+
+Proxy VMs are started dynamically using the `proxy-tmpl` template.
+
+### Create or Update the Instance Template
+
+```bash
+pnpm nx create-template proxy
+```
+
+Equivalent `gcloud` command:
+
+```bash
+gcloud compute instance-templates delete proxy-tmpl --quiet || true
+gcloud compute instance-templates create proxy-tmpl \
+  --machine-type=f1-micro \
+  --image-family=cos-stable \
+  --image-project=cos-cloud \
+  --boot-disk-size=10GB \
+  --boot-disk-type=pd-balanced \
+  --tags=http-server \
+  --scopes=cloud-platform \
+  --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true \
+  --metadata-from-file=user-data=apps/proxy/cloud-config.yaml
+```
+
+## Verification & Troubleshooting
+
+If a proxy VM is running (created by fetcher), you can check its status:
+
+```bash
+# List active proxy instances
+gcloud compute instances list --filter="labels.proxy:*"
+
+# Check systemd status on a running proxy VM
+gcloud compute ssh <PROXY_VM_NAME> --zone=<ZONE> --command="sudo systemctl status proxy.service"
+
+# View proxy container logs on a running proxy VM
+gcloud compute ssh <PROXY_VM_NAME> --zone=<ZONE> --command="docker logs -f proxy"
+```

--- a/apps/proxy/README.md
+++ b/apps/proxy/README.md
@@ -1,6 +1,6 @@
 # FlyXC Proxy
 
-The Proxy service runs in a container on temporary Google Compute Engine VMs using Container-Optimized OS (COS). Proxy VMs are created and terminated dynamically by `fetcher` ([`apps/fetcher/src/app/trackers/proxies.ts`](file:///home/victor/code/flyXC/apps/fetcher/src/app/trackers/proxies.ts)) using the `proxy-tmpl` instance template.
+The Proxy service runs in a container on temporary Google Compute Engine VMs using Container-Optimized OS (COS). Proxy VMs are created and terminated dynamically by `fetcher` ([`apps/fetcher/src/app/trackers/proxies.ts`](../fetcher/src/app/trackers/proxies.ts)) using the `proxy-tmpl` instance template.
 
 ## Build & Deploy Image
 

--- a/apps/proxy/cloud-config.yaml
+++ b/apps/proxy/cloud-config.yaml
@@ -1,0 +1,27 @@
+#cloud-config
+
+write_files:
+  - path: /etc/systemd/system/proxy.service
+    permissions: "0644"
+    owner: root
+    content: |
+      [Unit]
+      Description=FlyXC Proxy Container
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      TimeoutStartSec=0
+      Restart=always
+      Environment="DOCKER_CONFIG=/var/lib/docker-config"
+      ExecStartPre=/bin/mkdir -p /var/lib/docker-config
+      ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries us-docker.pkg.dev
+      ExecStartPre=-/usr/bin/docker stop proxy
+      ExecStartPre=-/usr/bin/docker rm proxy
+      ExecStartPre=/usr/bin/docker pull us-docker.pkg.dev/fly-xc/docker/proxy:latest
+      ExecStart=/usr/bin/docker run --name proxy --rm -p 80:80 us-docker.pkg.dev/fly-xc/docker/proxy:latest
+      ExecStop=/usr/bin/docker stop proxy
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl restart proxy.service

--- a/apps/proxy/cloud-config.yaml
+++ b/apps/proxy/cloud-config.yaml
@@ -22,6 +22,9 @@ write_files:
       ExecStart=/usr/bin/docker run --name proxy --rm -p 80:80 us-docker.pkg.dev/fly-xc/docker/proxy:latest
       ExecStop=/usr/bin/docker stop proxy
 
+      [Install]
+      WantedBy=multi-user.target
+
 runcmd:
   - systemctl daemon-reload
-  - systemctl restart proxy.service
+  - systemctl enable --now proxy.service

--- a/apps/proxy/project.json
+++ b/apps/proxy/project.json
@@ -69,6 +69,12 @@
         "pull": true,
         "tags": ["us-docker.pkg.dev/fly-xc/docker/proxy"]
       }
+    },
+    "create-template": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "gcloud compute instance-templates delete proxy-tmpl --quiet || true && gcloud compute instance-templates create proxy-tmpl --machine-type=f1-micro --image-family=cos-stable --image-project=cos-cloud --boot-disk-size=10GB --boot-disk-type=pd-balanced --tags=http-server --scopes=cloud-platform --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true --metadata-from-file=user-data=apps/proxy/cloud-config.yaml"
+      }
     }
   }
 }


### PR DESCRIPTION
See https://docs.cloud.google.com/compute/docs/containers/migrate-containers

## Summary by Sourcery

Replace Konlet-based container deployment with cloud-init and systemd-managed containers on Google Compute Engine VMs.

Enhancements:
- Migrate Fetcher and Proxy VM container management from Konlet to cloud-init-provisioned systemd services on Container-Optimized OS.
- Add reusable Nx commands and operational documentation for creating instance templates, provisioning VMs, deploying images, and troubleshooting services.

Deployment:
- Configure Fetcher and Proxy GCE instance templates to bootstrap and run Artifact Registry containers through cloud-init and systemd.

Documentation:
- Document the new Fetcher and Proxy VM lifecycle, deployment, verification, and troubleshooting workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infrastructure automation for deploying and managing the Fetcher and Proxy services on Google Cloud.
  * Added VM startup configuration to automatically launch service containers and restart them after VM reboots.
  * Added Fetcher workflows for creating instance templates, provisioning VMs, and restarting deployments.
  * Added Proxy workflow for creating reusable VM templates.
* **Documentation**
  * Added deployment, verification, operations, and troubleshooting guidance for both services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->