### PR TITLE
fix(fetcher): persist newly created ufo tracks map back to state

### DIFF
--- a/apps/fetcher/src/app/ufos/refresh.ts
+++ b/apps/fetcher/src/app/ufos/refresh.ts
@@ -36,7 +36,7 @@ export async function resfreshUfoFleets(pipeline: RedisClientMultiCmd, state: pr
 
   for (const fleetUpdate of fleetUpdates) {
     const { fleetName } = fleetUpdate;
-    const ufoTracks = state.ufoFleets[fleetName].ufos ?? {};
+    const ufoTracks = (state.ufoFleets[fleetName].ufos ??= {});
 
     for (const [id, track] of fleetUpdate.deltas.entries()) {
       if (ufoTracks[id] != null) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Persist newly initialized UFO track maps in fleet state so subsequent updates are retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed UFO fleet updates so newly tracked UFO data is correctly saved when no existing UFO records are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->