### PR TITLE
Reduce Redis bw

### DIFF
--- a/apps/fetcher/src/fetcher.ts
+++ b/apps/fetcher/src/fetcher.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 // Do not use "process" because the global "process.env" is
 // replaced at build time by Vite.
 import nodeProcess from 'node:process';
+import * as zlib from 'node:zlib';
 
 import { Keys, LIVE_REFRESH_SEC, protos } from '@flyxc/common';
 import type { RedisClientMultiCmd } from '@flyxc/common-node';
@@ -151,16 +152,34 @@ async function updateAll(pipeline: RedisClientMultiCmd, state: protos.FetcherSta
       createLiveTrackGroups(state, nowSec);
 
     pipeline
-      .set(Keys.fetcherFullProtoH12, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH12)))
-      .set(Keys.fetcherFullProtoH24, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH24)))
-      .set(Keys.fetcherFullProtoH48, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH48)))
+      .set(
+        Keys.fetcherFullProtoH12,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH12))),
+      )
+      .set(
+        Keys.fetcherFullProtoH24,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH24))),
+      )
+      .set(
+        Keys.fetcherFullProtoH48,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(fullTracksH48))),
+      )
       .set(Keys.fetcherFullNumTracksH12, fullTracksH12.tracks.length)
       .set(Keys.fetcherFullNumTracksH24, fullTracksH24.tracks.length)
       .set(Keys.fetcherFullNumTracksH48, fullTracksH48.tracks.length)
-      .set(Keys.fetcherLongIncrementalProto, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(longIncTracks)))
-      .set(Keys.fetcherShortIncrementalProto, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(shortIncTracks)))
+      .set(
+        Keys.fetcherLongIncrementalProto,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(longIncTracks))),
+      )
+      .set(
+        Keys.fetcherShortIncrementalProto,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(shortIncTracks))),
+      )
       .set(Keys.fetcherIncrementalNumTracksLong, longIncTracks.tracks.length)
-      .set(Keys.fetcherExportFlymeProto, protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(flymeTracks)));
+      .set(
+        Keys.fetcherExportFlymeProto,
+        zlib.gzipSync(protoToBuffer(protos.LiveDifferentialTrackGroup.toBinary(flymeTracks))),
+      );
   } catch (e) {
     console.log(`tick error ${e}`);
   } finally {

--- a/apps/fxc-server/package.json
+++ b/apps/fxc-server/package.json
@@ -26,7 +26,6 @@
     "igc-parser": "^2.0.0",
     "object-standard-path": "^0.3.1",
     "printf": "^0.6.1",
-    "redis": "catalog:default",
     "vaadin-nodom": "workspace:*",
     "xmlbuilder": "^15.1.1",
     "zod": "catalog:default"

--- a/apps/fxc-server/src/app/routes/admin.ts
+++ b/apps/fxc-server/src/app/routes/admin.ts
@@ -38,7 +38,7 @@ export function getAdminRouter(redis: RedisClient, datastore: Datastore): Router
       const bufferRedis = redis.withTypeMapping({
         [RESP_TYPES.BLOB_STRING]: Buffer,
       });
-      const state = await bufferRedis.get(Keys.fetcherStateBrotli);
+      const state = (await bufferRedis.get(Keys.fetcherStateBrotli)) as Buffer | null;
       if (state) {
         return res.send(zlib.brotliDecompressSync(state));
       }

--- a/apps/fxc-server/src/app/routes/admin.ts
+++ b/apps/fxc-server/src/app/routes/admin.ts
@@ -3,11 +3,10 @@ import zlib from 'node:zlib';
 import csurf from '@dr.pogodin/csurf';
 import { AccountFormModel, Keys, trackerNames, ufoFleetNames } from '@flyxc/common';
 import type { RedisClient } from '@flyxc/common-node';
-import { retrieveLiveTrackById, retrieveRecentTracks, TRACK_TABLE } from '@flyxc/common-node';
+import { getBufferRedisClient, retrieveLiveTrackById, retrieveRecentTracks, TRACK_TABLE } from '@flyxc/common-node';
 import { Datastore } from '@google-cloud/datastore';
 import type { NextFunction, Request, Response } from 'express';
 import { Router } from 'express';
-import { RESP_TYPES } from 'redis';
 
 import { createOrUpdateLiveTrack } from './live-track';
 import { isAdmin } from './session';
@@ -35,9 +34,7 @@ export function getAdminRouter(redis: RedisClient, datastore: Datastore): Router
     res.set('Cache-Control', 'no-store');
 
     try {
-      const bufferRedis = redis.withTypeMapping({
-        [RESP_TYPES.BLOB_STRING]: Buffer,
-      });
+      const bufferRedis = getBufferRedisClient(redis);
       const state = (await bufferRedis.get(Keys.fetcherStateBrotli)) as Buffer | null;
       if (state) {
         return res.send(zlib.brotliDecompressSync(state));

--- a/apps/fxc-server/src/app/routes/live-track.test.ts
+++ b/apps/fxc-server/src/app/routes/live-track.test.ts
@@ -122,6 +122,46 @@ describe('live-track routes and helpers', () => {
       await getCachedProto(mockRedis, 'test:key');
       expect(mockRedis.get).toHaveBeenCalledTimes(2);
     });
+
+    it('should deduplicate concurrent in-flight requests for the same key', async () => {
+      let resolveRedis: (val: Buffer) => void;
+      const delayedPromise = new Promise<Buffer>((resolve) => {
+        resolveRedis = resolve;
+      });
+
+      const mockRedis = {
+        get: vi.fn().mockReturnValue(delayedPromise),
+      } as any;
+
+      // Start multiple concurrent requests simultaneously
+      const req1 = getCachedProto(mockRedis, 'concurrent:key');
+      const req2 = getCachedProto(mockRedis, 'concurrent:key');
+      const req3 = getCachedProto(mockRedis, 'concurrent:key');
+
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+
+      resolveRedis!(gzippedData);
+
+      const [res1, res2, res3] = await Promise.all([req1, req2, req3]);
+      expect(res1).toBe(gzippedData);
+      expect(res2).toBe(gzippedData);
+      expect(res3).toBe(gzippedData);
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should delete in-flight cache entry when Redis call fails and allow subsequent retries', async () => {
+      const mockRedis = {
+        get: vi.fn().mockRejectedValueOnce(new Error('Redis connection failed')).mockResolvedValueOnce(gzippedData),
+      } as any;
+
+      await expect(getCachedProto(mockRedis, 'error:key')).rejects.toThrow('Redis connection failed');
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+
+      // Subsequent call should retry and succeed
+      const retryRes = await getCachedProto(mockRedis, 'error:key');
+      expect(retryRes).toBe(gzippedData);
+      expect(mockRedis.get).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('sendProtobufResponse', () => {

--- a/apps/fxc-server/src/app/routes/live-track.test.ts
+++ b/apps/fxc-server/src/app/routes/live-track.test.ts
@@ -4,7 +4,15 @@ import { Keys, LiveDataRetentionSec } from '@flyxc/common';
 import type { Request, Response } from 'express';
 import { describe, expect, it, vi } from 'vitest';
 
-import { ensureDecompressed, isGzip, resolveLiveTrackKey, sendProtobufResponse } from './live-track';
+import {
+  clearProtoCache,
+  ensureDecompressed,
+  getCachedProto,
+  isGzip,
+  LIVE_TRACK_CACHE_TTL_MS,
+  resolveLiveTrackKey,
+  sendProtobufResponse,
+} from './live-track';
 
 describe('live-track routes and helpers', () => {
   const rawData = Buffer.from('hello-live-track-data');
@@ -70,6 +78,49 @@ describe('live-track routes and helpers', () => {
     it('should default to FullProtoH12 for full requests', () => {
       const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalLong + 100);
       expect(resolveLiveTrackKey(lastUpdateSec, 0, nowSec)).toBe(Keys.fetcherFullProtoH12);
+    });
+  });
+
+  describe('getCachedProto', () => {
+    beforeEach(() => {
+      clearProtoCache();
+    });
+
+    it('should fetch from Redis on cache miss and return cached value on subsequent calls within TTL', async () => {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(gzippedData),
+      } as any;
+
+      const baseTimeMs = 1_000_000;
+
+      // 1. Initial call (cache miss)
+      const res1 = await getCachedProto(mockRedis, 'test:key', LIVE_TRACK_CACHE_TTL_MS, baseTimeMs);
+      expect(res1).toBe(gzippedData);
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+
+      // 2. Second call within TTL (cache hit)
+      const res2 = await getCachedProto(mockRedis, 'test:key', LIVE_TRACK_CACHE_TTL_MS, baseTimeMs + 10_000);
+      expect(res2).toBe(gzippedData);
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+
+      // 3. Third call after TTL expires (cache expired -> re-fetch)
+      const res3 = await getCachedProto(mockRedis, 'test:key', LIVE_TRACK_CACHE_TTL_MS, baseTimeMs + 21_000);
+      expect(res3).toBe(gzippedData);
+      expect(mockRedis.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear cache on clearProtoCache()', async () => {
+      const mockRedis = {
+        get: vi.fn().mockResolvedValue(rawData),
+      } as any;
+
+      await getCachedProto(mockRedis, 'test:key');
+      expect(mockRedis.get).toHaveBeenCalledTimes(1);
+
+      clearProtoCache();
+
+      await getCachedProto(mockRedis, 'test:key');
+      expect(mockRedis.get).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/fxc-server/src/app/routes/live-track.test.ts
+++ b/apps/fxc-server/src/app/routes/live-track.test.ts
@@ -1,0 +1,142 @@
+import * as zlib from 'node:zlib';
+
+import { Keys, LiveDataRetentionSec } from '@flyxc/common';
+import type { Request, Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureDecompressed, isGzip, resolveLiveTrackKey, sendProtobufResponse } from './live-track';
+
+describe('live-track routes and helpers', () => {
+  const rawData = Buffer.from('hello-live-track-data');
+  const gzippedData = zlib.gzipSync(rawData);
+
+  describe('isGzip', () => {
+    it('should detect valid gzip buffers with magic header (0x1f, 0x8b)', () => {
+      expect(isGzip(gzippedData)).toBe(true);
+    });
+
+    it('should return false for uncompressed buffers', () => {
+      expect(isGzip(rawData)).toBe(false);
+    });
+
+    it('should return false for short or null/undefined buffers', () => {
+      expect(isGzip(null)).toBe(false);
+      expect(isGzip(undefined)).toBe(false);
+      expect(isGzip(Buffer.from([0x1f]))).toBe(false);
+      expect(isGzip(Buffer.alloc(0))).toBe(false);
+    });
+  });
+
+  describe('ensureDecompressed', () => {
+    it('should decompress gzipped buffers', () => {
+      const result = ensureDecompressed(gzippedData);
+      expect(result).not.toBeNull();
+      expect(result?.toString()).toBe('hello-live-track-data');
+    });
+
+    it('should return uncompressed buffers unchanged', () => {
+      const result = ensureDecompressed(rawData);
+      expect(result).toBe(rawData);
+    });
+
+    it('should return null for null input', () => {
+      expect(ensureDecompressed(null)).toBeNull();
+    });
+  });
+
+  describe('resolveLiveTrackKey', () => {
+    const nowSec = 100000;
+
+    it('should return ShortIncremental key when lastUpdate is very recent', () => {
+      const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalShort - 10);
+      expect(resolveLiveTrackKey(lastUpdateSec, 0, nowSec)).toBe(Keys.fetcherShortIncrementalProto);
+    });
+
+    it('should return LongIncremental key when lastUpdate is moderately recent', () => {
+      const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalLong - 10);
+      expect(resolveLiveTrackKey(lastUpdateSec, 0, nowSec)).toBe(Keys.fetcherLongIncrementalProto);
+    });
+
+    it('should return FullProtoH24 when fm is 24 * 60', () => {
+      const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalLong + 100);
+      expect(resolveLiveTrackKey(lastUpdateSec, 24 * 60, nowSec)).toBe(Keys.fetcherFullProtoH24);
+    });
+
+    it('should return FullProtoH48 when fm is 48 * 60', () => {
+      const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalLong + 100);
+      expect(resolveLiveTrackKey(lastUpdateSec, 48 * 60, nowSec)).toBe(Keys.fetcherFullProtoH48);
+    });
+
+    it('should default to FullProtoH12 for full requests', () => {
+      const lastUpdateSec = nowSec - (LiveDataRetentionSec.IncrementalLong + 100);
+      expect(resolveLiveTrackKey(lastUpdateSec, 0, nowSec)).toBe(Keys.fetcherFullProtoH12);
+    });
+  });
+
+  describe('sendProtobufResponse', () => {
+    function createMockRes() {
+      const headers: Record<string, string> = {};
+      const res: Partial<Response> = {
+        set: vi.fn((key: string | Record<string, string>, value?: string) => {
+          if (typeof key === 'string' && value) {
+            headers[key] = value;
+          }
+          return res as Response;
+        }),
+        send: vi.fn(),
+      };
+      return { res: res as Response, headers };
+    }
+
+    it('should serve pre-gzipped buffer with Content-Encoding: gzip when client accepts gzip', () => {
+      const req = {
+        acceptsEncodings: vi.fn((encoding: string) => (encoding === 'gzip' ? 'gzip' : false)),
+      } as unknown as Request;
+
+      const { res, headers } = createMockRes();
+      sendProtobufResponse(req, res, gzippedData);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
+      expect(res.set).toHaveBeenCalledWith('Content-Encoding', 'gzip');
+      expect(res.send).toHaveBeenCalledWith(gzippedData);
+    });
+
+    it('should decompress gzipped buffer on the fly when client does not accept gzip', () => {
+      const req = {
+        acceptsEncodings: vi.fn(() => false),
+      } as unknown as Request;
+
+      const { res, headers } = createMockRes();
+      sendProtobufResponse(req, res, gzippedData);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
+      expect(headers['Content-Encoding']).toBeUndefined();
+      expect(res.send).toHaveBeenCalledWith(rawData);
+    });
+
+    it('should serve uncompressed buffer as-is', () => {
+      const req = {
+        acceptsEncodings: vi.fn((encoding: string) => (encoding === 'gzip' ? 'gzip' : false)),
+      } as unknown as Request;
+
+      const { res, headers } = createMockRes();
+      sendProtobufResponse(req, res, rawData);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
+      expect(headers['Content-Encoding']).toBeUndefined();
+      expect(res.send).toHaveBeenCalledWith(rawData);
+    });
+
+    it('should handle null buffer gracefully', () => {
+      const req = {
+        acceptsEncodings: vi.fn(() => false),
+      } as unknown as Request;
+
+      const { res } = createMockRes();
+      sendProtobufResponse(req, res, null);
+
+      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
+      expect(res.send).toHaveBeenCalledWith(Buffer.alloc(0));
+    });
+  });
+});

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -115,10 +115,13 @@ export function sendProtobufResponse(req: Request, res: Response, buffer: Buffer
 /** In-memory cache TTL for live track protobuf buffers in milliseconds. */
 export const LIVE_TRACK_CACHE_TTL_MS = 20 * 1000;
 
-const protoCache = new Map<string, { data: Buffer | null; expiresAtMs: number }>();
+type CacheEntry = { data: Buffer | null; expiresAtMs: number } | { inFlight: Promise<Buffer | null> };
+
+const protoCache = new Map<string, CacheEntry>();
 
 /**
  * Retrieves a live track buffer from the in-memory cache or falls back to Redis.
+ * Deduplicates concurrent in-flight requests for the same key.
  *
  * @param bufferRedis - Redis client configured for binary buffers.
  * @param key - Redis key to retrieve.
@@ -133,12 +136,28 @@ export async function getCachedProto(
   nowMs = Date.now(),
 ): Promise<Buffer | null> {
   const cached = protoCache.get(key);
-  if (cached && cached.expiresAtMs > nowMs) {
-    return cached.data;
+  if (cached) {
+    if ('data' in cached && cached.expiresAtMs > nowMs) {
+      return cached.data;
+    }
+    if ('inFlight' in cached) {
+      return cached.inFlight;
+    }
   }
-  const data = (await bufferRedis.get(key)) as Buffer | null;
-  protoCache.set(key, { data, expiresAtMs: nowMs + ttlMs });
-  return data;
+
+  const inFlightPromise = (async () => {
+    try {
+      const data = (await bufferRedis.get(key)) as Buffer | null;
+      protoCache.set(key, { data, expiresAtMs: nowMs + ttlMs });
+      return data;
+    } catch (err) {
+      protoCache.delete(key);
+      throw err;
+    }
+  })();
+
+  protoCache.set(key, { inFlight: inFlightPromise });
+  return inFlightPromise;
 }
 
 /**

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -1,11 +1,13 @@
 import crypto from 'node:crypto';
+import * as zlib from 'node:zlib';
 
 import csurf from '@dr.pogodin/csurf';
 import type { AccountModel, LiveTrackEntity } from '@flyxc/common';
-import { AccountFormModel, differentialDecodeLiveTrack, Keys, LiveDataRetentionSec, protos } from '@flyxc/common';
-import type { RedisClient } from '@flyxc/common-node';
+import { AccountFormModel, Keys, LiveDataRetentionSec, protos } from '@flyxc/common';
+import type { BufferRedisClient, RedisClient } from '@flyxc/common-node';
 import {
   FlyMeValidator,
+  getBufferRedisClient,
   InreachValidator,
   LIVE_TRACK_TABLE,
   retrieveLiveTrackByGoogleId,
@@ -15,7 +17,6 @@ import {
 import { Datastore } from '@google-cloud/datastore';
 import type { Request, Response } from 'express';
 import { Router } from 'express';
-import { RESP_TYPES } from 'redis';
 import { NoDomBinder } from 'vaadin-nodom';
 
 import { getUserInfo, isLoggedIn, logout } from './session';
@@ -23,99 +24,197 @@ import { getUserInfo, isLoggedIn, logout } from './session';
 // Store the token in the session.
 const csrfProtection = csurf();
 
+/**
+ * Checks if the buffer starts with the standard Gzip magic bytes (0x1f, 0x8b).
+ *
+ * @param buffer - The buffer or Uint8Array to test.
+ * @returns `true` if the buffer has a Gzip magic header, `false` otherwise.
+ */
+export function isGzip(buffer: Buffer | Uint8Array | null | undefined): boolean {
+  return buffer != null && buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
+}
+
+/**
+ * Decompresses a buffer if it is gzip-compressed; otherwise returns it as-is.
+ *
+ * @param buffer - The raw or compressed buffer from Redis.
+ * @returns The uncompressed buffer, or `null` if the input was null.
+ */
+export function ensureDecompressed(buffer: Buffer | null): Buffer | null {
+  if (!buffer) {
+    return null;
+  }
+  return isGzip(buffer) ? zlib.gunzipSync(buffer) : buffer;
+}
+
+/**
+ * Resolves the appropriate Redis key for live tracks based on the client's last
+ * update timestamp delta and requested history duration (in minutes).
+ *
+ * @param lastUpdateSec - Timestamp in seconds of the client's last update.
+ * @param fetchMinutes - Requested duration of track history in minutes.
+ * @param nowSec - Current timestamp in seconds (defaults to current time).
+ * @returns The matching Redis key for incremental or full track data.
+ */
+export function resolveLiveTrackKey(
+  lastUpdateSec: number,
+  fetchMinutes: number,
+  nowSec = Math.round(Date.now() / 1000),
+): Keys {
+  const deltaSec = nowSec - lastUpdateSec;
+
+  // Pick the incremental proto if the last request was recent.
+  if (deltaSec < LiveDataRetentionSec.IncrementalShort) {
+    return Keys.fetcherShortIncrementalProto;
+  }
+  if (deltaSec < LiveDataRetentionSec.IncrementalLong) {
+    return Keys.fetcherLongIncrementalProto;
+  }
+
+  // Otherwise, return full tracks for the requested history range.
+  switch (fetchMinutes) {
+    case 24 * 60:
+      return Keys.fetcherFullProtoH24;
+    case 48 * 60:
+      return Keys.fetcherFullProtoH48;
+    default:
+      return Keys.fetcherFullProtoH12;
+  }
+}
+
+/**
+ * Sends a protobuf buffer to the client, handling Gzip transparently:
+ * - If the buffer from Redis is gzipped and the client accepts gzip, sends with `Content-Encoding: gzip` (no server CPU decompression).
+ * - If the buffer from Redis is gzipped and the client does not accept gzip, decompresses on-the-fly.
+ * - If the buffer from Redis is uncompressed (legacy format during migration), sends as raw protobuf.
+ *
+ * @param req - Express request object used to check accepted encodings.
+ * @param res - Express response object.
+ * @param buffer - The protobuf buffer (gzipped, raw, or null).
+ */
+export function sendProtobufResponse(req: Request, res: Response, buffer: Buffer | null): void {
+  res.set('Content-Type', 'application/x-protobuf');
+
+  if (!buffer) {
+    res.send(Buffer.alloc(0));
+    return;
+  }
+
+  if (isGzip(buffer)) {
+    if (req.acceptsEncodings('gzip') === 'gzip') {
+      res.set('Content-Encoding', 'gzip');
+      res.send(buffer);
+    } else {
+      res.send(zlib.gunzipSync(buffer));
+    }
+  } else {
+    res.send(buffer);
+  }
+}
+
+/**
+ * Handles authorized partner token requests (e.g. FlyMe, Wing, Zipline).
+ *
+ * @param req - Express request object.
+ * @param res - Express response object.
+ * @param token - The partner authorization token.
+ * @param bufferRedis - Redis client configured for binary buffers.
+ */
+export async function handlePartnerTokenRequest(
+  req: Request,
+  res: Response,
+  token: string,
+  bufferRedis: BufferRedisClient,
+): Promise<void> {
+  switch (token) {
+    case SECRETS.FLYME_TOKEN: {
+      const groupProto = (await bufferRedis.get(Keys.fetcherExportFlymeProto)) as Buffer | null;
+      if (req.header('accept') === 'application/json') {
+        const uncompressed = ensureDecompressed(groupProto);
+        const track = uncompressed
+          ? protos.LiveDifferentialTrackGroup.fromBinary(uncompressed)
+          : protos.LiveDifferentialTrackGroup.create();
+        res.json(protos.LiveDifferentialTrackGroup.toJson(track));
+      } else {
+        sendProtobufResponse(req, res, groupProto);
+      }
+      break;
+    }
+    case SECRETS.WING_TOKEN:
+    case SECRETS.ZIPLINE_TOKEN: {
+      const liveGroupProto = (await bufferRedis.get(Keys.fetcherFullProtoH12)) as Buffer | null;
+      const uncompressed = ensureDecompressed(liveGroupProto);
+
+      const liveGroup = uncompressed
+        ? protos.LiveDifferentialTrackGroup.fromBinary(uncompressed)
+        : protos.LiveDifferentialTrackGroup.create();
+
+      const anonTracks: protos.LiveDifferentialTrack[] = liveGroup.tracks.map(
+        ({ lat, lon, alt, timeSec, id, idStr }) => {
+          // Anonymizes the track by hashing the id with a salt.
+          const sha1 = crypto.createHash('sha1');
+          sha1.update(String(idStr ?? id) + SECRETS.EXPORT_ID_SALT);
+
+          return {
+            idStr: sha1.digest('hex'),
+            name: '',
+            flags: [],
+            extra: {},
+            lat,
+            lon,
+            alt,
+            timeSec,
+          };
+        },
+      );
+      const anonGroup: protos.LiveDifferentialTrackGroup = {
+        tracks: anonTracks,
+        incremental: false,
+        remoteId: [],
+      };
+
+      if (req.header('accept') === 'application/json') {
+        res.json(protos.LiveDifferentialTrackGroup.toJson(anonGroup));
+      } else {
+        res.set('Content-Type', 'application/x-protobuf');
+        res.send(protos.LiveDifferentialTrackGroup.toBinary(anonGroup));
+      }
+      break;
+    }
+    default:
+      res.sendStatus(400);
+  }
+}
+
+/**
+ * Creates and configures the Express router for live tracking endpoints.
+ *
+ * @param redis - Redis client instance.
+ * @param datastore - Google Cloud Datastore client instance.
+ * @returns Configured Express Router.
+ */
 export function getTrackerRouter(redis: RedisClient, datastore: Datastore): Router {
   const router = Router();
-  const bufferRedis = redis.withTypeMapping({
-    [RESP_TYPES.BLOB_STRING]: Buffer,
-  });
+  const bufferRedis = getBufferRedisClient(redis);
 
-  // Get the geojson for the currently active trackers.
+  // Get the live tracks (in protobuf or JSON format).
   router.get('/tracks.pbf', async (req: Request, res: Response) => {
     res.set('Cache-Control', 'no-store');
+
+    // 1. Handle partner token requests (e.g. FlyMe, Wing, Zipline).
     const token = req.header('token');
     if (token) {
-      switch (token) {
-        case SECRETS.FLYME_TOKEN: {
-          const groupProto = (await bufferRedis.get(Keys.fetcherExportFlymeProto)) as Buffer | null;
-          if (req.header('accept') == 'application/json') {
-            const track = protos.LiveDifferentialTrackGroup.fromBinary(groupProto!);
-            res.json(protos.LiveDifferentialTrackGroup.toJson(track));
-          } else {
-            res.set('Content-Type', 'application/x-protobuf');
-            res.send(groupProto);
-          }
-          break;
-        }
-        case SECRETS.WING_TOKEN:
-        case SECRETS.ZIPLINE_TOKEN: {
-          const liveGroupProto = (await bufferRedis.get(Keys.fetcherFullProtoH12)) as Buffer | null;
-
-          const liveGroup = liveGroupProto
-            ? protos.LiveDifferentialTrackGroup.fromBinary(liveGroupProto)
-            : protos.LiveDifferentialTrackGroup.create();
-
-          const anonTracks: protos.LiveDifferentialTrack[] = liveGroup.tracks.map(
-            ({ lat, lon, alt, timeSec, id, idStr }) => {
-              // Anonymizes the track by hashing the id with a salt.
-              const sha1 = crypto.createHash('sha1');
-              sha1.update(String(idStr ?? id) + SECRETS.EXPORT_ID_SALT);
-
-              return {
-                idStr: sha1.digest('hex'),
-                name: '',
-                flags: [],
-                extra: {},
-                lat,
-                lon,
-                alt,
-                timeSec,
-              };
-            },
-          );
-          const anonGroup: protos.LiveDifferentialTrackGroup = {
-            tracks: anonTracks,
-            incremental: false,
-            remoteId: [],
-          };
-
-          if (req.header('accept') == 'application/json') {
-            res.json(protos.LiveDifferentialTrackGroup.toJson(anonGroup));
-          } else {
-            res.set('Content-Type', 'application/x-protobuf');
-            res.send(protos.LiveDifferentialTrackGroup.toBinary(anonGroup));
-          }
-          break;
-        }
-        default:
-          res.sendStatus(400);
-      }
-    } else {
-      let key: Keys;
-      const lastUpdateSec = Number(req.query.s ?? 0);
-      const nowSec = Math.round(Date.now() / 1000);
-      const deltaSec = nowSec - lastUpdateSec;
-      // Pick the incremental proto if last request was recent.
-      if (deltaSec < LiveDataRetentionSec.IncrementalShort) {
-        key = Keys.fetcherShortIncrementalProto;
-      } else if (deltaSec < LiveDataRetentionSec.IncrementalLong) {
-        key = Keys.fetcherLongIncrementalProto;
-      } else {
-        switch (Number(req.query.fm ?? 0)) {
-          case 24 * 60:
-            key = Keys.fetcherFullProtoH24;
-            break;
-
-          case 48 * 60:
-            key = Keys.fetcherFullProtoH48;
-            break;
-
-          default:
-            key = Keys.fetcherFullProtoH12;
-        }
-      }
-      res.set('Content-Type', 'application/x-protobuf');
-      res.send(await bufferRedis.get(key));
+      await handlePartnerTokenRequest(req, res, token, bufferRedis);
+      return;
     }
+
+    // 2. Handle public live track requests based on client time delta and history range.
+    const lastUpdateSec = Number(req.query.s ?? 0);
+    const fetchMin = Number(req.query.fm ?? 0);
+    const key = resolveLiveTrackKey(lastUpdateSec, fetchMin);
+
+    const protoBuffer = (await bufferRedis.get(key)) as Buffer | null;
+    sendProtobufResponse(req, res, protoBuffer);
   });
 
   // Get the account information.
@@ -175,7 +274,18 @@ export function getTrackerRouter(redis: RedisClient, datastore: Datastore): Rout
   return router;
 }
 
-// Create or update a LiveTrack entity from the form POST data.
+/**
+ * Creates or updates a LiveTrack entity from validated form POST data.
+ *
+ * @param datastore - Google Cloud Datastore client instance.
+ * @param entity - Existing LiveTrack entity if available.
+ * @param req - Express request object.
+ * @param res - Express response object.
+ * @param email - User email address.
+ * @param googleId - User Google ID token.
+ * @param redis - Redis client instance.
+ * @returns JSON response indicating success or validation/server errors.
+ */
 export async function createOrUpdateLiveTrack(
   datastore: Datastore,
   entity: LiveTrackEntity | undefined,

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -36,7 +36,7 @@ export function getTrackerRouter(redis: RedisClient, datastore: Datastore): Rout
     if (token) {
       switch (token) {
         case SECRETS.FLYME_TOKEN: {
-          const groupProto = await bufferRedis.get(Keys.fetcherExportFlymeProto);
+          const groupProto = (await bufferRedis.get(Keys.fetcherExportFlymeProto)) as Buffer | null;
           if (req.header('accept') == 'application/json') {
             const track = protos.LiveDifferentialTrackGroup.fromBinary(groupProto!);
             res.json(protos.LiveDifferentialTrackGroup.toJson(track));
@@ -48,7 +48,7 @@ export function getTrackerRouter(redis: RedisClient, datastore: Datastore): Rout
         }
         case SECRETS.WING_TOKEN:
         case SECRETS.ZIPLINE_TOKEN: {
-          const liveGroupProto = await bufferRedis.get(Keys.fetcherFullProtoH12);
+          const liveGroupProto = (await bufferRedis.get(Keys.fetcherFullProtoH12)) as Buffer | null;
 
           const liveGroup = liveGroupProto
             ? protos.LiveDifferentialTrackGroup.fromBinary(liveGroupProto)

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -112,6 +112,42 @@ export function sendProtobufResponse(req: Request, res: Response, buffer: Buffer
   }
 }
 
+/** In-memory cache TTL for live track protobuf buffers in milliseconds. */
+export const LIVE_TRACK_CACHE_TTL_MS = 20 * 1000;
+
+const protoCache = new Map<string, { data: Buffer | null; expiresAtMs: number }>();
+
+/**
+ * Retrieves a live track buffer from the in-memory cache or falls back to Redis.
+ *
+ * @param bufferRedis - Redis client configured for binary buffers.
+ * @param key - Redis key to retrieve.
+ * @param ttlMs - Cache TTL in milliseconds (defaults to 20s).
+ * @param nowMs - Current timestamp in milliseconds (defaults to Date.now()).
+ * @returns The protobuf buffer or null.
+ */
+export async function getCachedProto(
+  bufferRedis: BufferRedisClient,
+  key: string,
+  ttlMs = LIVE_TRACK_CACHE_TTL_MS,
+  nowMs = Date.now(),
+): Promise<Buffer | null> {
+  const cached = protoCache.get(key);
+  if (cached && cached.expiresAtMs > nowMs) {
+    return cached.data;
+  }
+  const data = (await bufferRedis.get(key)) as Buffer | null;
+  protoCache.set(key, { data, expiresAtMs: nowMs + ttlMs });
+  return data;
+}
+
+/**
+ * Clears the in-memory live track buffer cache. Useful for testing.
+ */
+export function clearProtoCache(): void {
+  protoCache.clear();
+}
+
 /**
  * Handles authorized partner token requests (e.g. FlyMe, Wing, Zipline).
  *
@@ -128,7 +164,7 @@ export async function handlePartnerTokenRequest(
 ): Promise<void> {
   switch (token) {
     case SECRETS.FLYME_TOKEN: {
-      const groupProto = (await bufferRedis.get(Keys.fetcherExportFlymeProto)) as Buffer | null;
+      const groupProto = await getCachedProto(bufferRedis, Keys.fetcherExportFlymeProto);
       if (req.header('accept') === 'application/json') {
         const uncompressed = ensureDecompressed(groupProto);
         const track = uncompressed
@@ -142,7 +178,7 @@ export async function handlePartnerTokenRequest(
     }
     case SECRETS.WING_TOKEN:
     case SECRETS.ZIPLINE_TOKEN: {
-      const liveGroupProto = (await bufferRedis.get(Keys.fetcherFullProtoH12)) as Buffer | null;
+      const liveGroupProto = await getCachedProto(bufferRedis, Keys.fetcherFullProtoH12);
       const uncompressed = ensureDecompressed(liveGroupProto);
 
       const liveGroup = uncompressed
@@ -212,8 +248,7 @@ export function getTrackerRouter(redis: RedisClient, datastore: Datastore): Rout
     const lastUpdateSec = Number(req.query.s ?? 0);
     const fetchMin = Number(req.query.fm ?? 0);
     const key = resolveLiveTrackKey(lastUpdateSec, fetchMin);
-
-    const protoBuffer = (await bufferRedis.get(key)) as Buffer | null;
+    const protoBuffer = await getCachedProto(bufferRedis, key);
     sendProtobufResponse(req, res, protoBuffer);
   });
 

--- a/apps/fxc-server/src/app/routes/zoleo.ts
+++ b/apps/fxc-server/src/app/routes/zoleo.ts
@@ -131,7 +131,7 @@ export function getZoleoRouter(redis: RedisClient): Router {
     try {
       const json = JSON.stringify(parseMessage(req.body));
       if (json != null) {
-        const pipeline = redis.pipeline();
+        const pipeline = redis.multi();
         pushListCap(pipeline, Keys.zoleoMsgQueue, [json], ZOLEO_MAX_MSG, ZOLEO_MAX_MSG_SIZE);
         await pipeline.execTyped(true);
       }

--- a/libs/common-node/src/lib/redis.test.ts
+++ b/libs/common-node/src/lib/redis.test.ts
@@ -1,0 +1,52 @@
+import type { RedisClientMultiCmd } from './redis';
+import { pushListCap } from './redis';
+
+describe('pushListCap', () => {
+  let mockPipeline: {
+    lPush: ReturnType<typeof vi.fn>;
+    lTrim: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockPipeline = {
+      lPush: vi.fn().mockReturnThis(),
+      lTrim: vi.fn().mockReturnThis(),
+    };
+  });
+
+  it('should not push or trim when the list is empty', () => {
+    const result = pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', [], 10);
+    expect(result).toBe(mockPipeline);
+    expect(mockPipeline.lPush).not.toHaveBeenCalled();
+    expect(mockPipeline.lTrim).not.toHaveBeenCalled();
+  });
+
+  it('should not push or trim when capacity is <= 0', () => {
+    const result = pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', ['item1'], 0);
+    expect(result).toBe(mockPipeline);
+    expect(mockPipeline.lPush).not.toHaveBeenCalled();
+    expect(mockPipeline.lTrim).not.toHaveBeenCalled();
+  });
+
+  it('should push elements and trim list to capacity', () => {
+    pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', ['a', 'b', 'c'], 5);
+    expect(mockPipeline.lPush).toHaveBeenCalledWith('test_key', ['a', 'b', 'c']);
+    expect(mockPipeline.lTrim).toHaveBeenCalledWith('test_key', 0, 4);
+  });
+
+  it('should only keep the last `capacity` elements when list is larger than capacity', () => {
+    pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', ['a', 'b', 'c', 'd', 'e'], 3);
+    expect(mockPipeline.lPush).toHaveBeenCalledWith('test_key', ['c', 'd', 'e']);
+    expect(mockPipeline.lTrim).toHaveBeenCalledWith('test_key', 0, 2);
+  });
+
+  it('should truncate elements longer than maxLength', () => {
+    pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', ['abcdefghij'], 5, 4);
+    expect(mockPipeline.lPush).toHaveBeenCalledWith('test_key', ['abcd']);
+  });
+
+  it('should convert numbers to strings', () => {
+    pushListCap(mockPipeline as unknown as RedisClientMultiCmd, 'test_key', [123, 456], 5);
+    expect(mockPipeline.lPush).toHaveBeenCalledWith('test_key', ['123', '456']);
+  });
+});

--- a/libs/common-node/src/lib/redis.ts
+++ b/libs/common-node/src/lib/redis.ts
@@ -1,7 +1,20 @@
-import { createClient, type RedisClientType } from 'redis';
+import { createClient, type RedisClientType, RESP_TYPES } from 'redis';
 
 export type RedisClient = RedisClientType;
 export type RedisClientMultiCmd = ReturnType<RedisClient['multi']>;
+export type BufferRedisClient = ReturnType<RedisClient['withTypeMapping']>;
+
+/**
+ * Returns a Redis client configured to return binary Buffers for blob strings.
+ *
+ * @param client - The standard RedisClient instance.
+ * @returns The buffer-mapped RedisClient.
+ */
+export function getBufferRedisClient(client: RedisClient): BufferRedisClient {
+  return client.withTypeMapping({
+    [RESP_TYPES.BLOB_STRING]: Buffer,
+  });
+}
 
 // lazily created client.
 let redis: RedisClient | undefined;

--- a/libs/common-node/src/lib/redis.ts
+++ b/libs/common-node/src/lib/redis.ts
@@ -1,6 +1,6 @@
 import { createClient, type RedisClientType } from 'redis';
 
-export type RedisClient = RedisClientType<any, any, any, any>;
+export type RedisClient = RedisClientType;
 export type RedisClientMultiCmd = ReturnType<RedisClient['multi']>;
 
 // lazily created client.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,9 +527,6 @@ importers:
       printf:
         specifier: ^0.6.1
         version: 0.6.1
-      redis:
-        specifier: catalog:default
-        version: 6.2.1(@opentelemetry/api@1.9.0)
       vaadin-nodom:
         specifier: workspace:*
         version: link:../../libs/vaadin-nodom


### PR DESCRIPTION
## Summary by Sourcery

Reduce Redis bandwidth and live-track request load by compressing stored protobufs and caching binary payloads at the server.

New Features:
- Compress live-track protobuf payloads stored in Redis and serve them with transparent gzip negotiation.
- Add short-lived in-memory caching and concurrent request deduplication for live-track Redis payloads.
- Provide shared binary Redis client configuration and migrate Zoleo queue writes to transactional multi commands.

Bug Fixes:
- Preserve compatibility with legacy uncompressed live-track payloads and clients that do not accept gzip.

Enhancements:
- Refactor live-track request handling into reusable key resolution, decompression, response, partner-export, and caching helpers.
- Centralize Redis buffer client typing and configuration in common-node.

Build:
- Remove the unused direct Redis dependency from the fxc-server application.

Tests:
- Add coverage for gzip handling, live-track key selection, caching behavior, request deduplication, response negotiation, and bounded Redis list updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Live tracking responses are briefly cached to improve repeated requests.
  - Compressed track data reduces transfer size and may improve response times.

- **Compatibility**
  - Gzip-compressed live tracking data is handled automatically, whether or not the requesting client supports gzip.
  - Existing uncompressed responses continue to work without changes.

- **Reliability**
  - Administrative state retrieval and Zoleo message processing now use more consistent Redis handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->