### PR TITLE
refactor(live): assume gzip format from Redis in fxc-server

### DIFF
--- a/apps/fxc-server/src/app/routes/live-track.test.ts
+++ b/apps/fxc-server/src/app/routes/live-track.test.ts
@@ -6,9 +6,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   clearProtoCache,
-  ensureDecompressed,
+  decompressProto,
   getCachedProto,
-  isGzip,
   LIVE_TRACK_CACHE_TTL_MS,
   resolveLiveTrackKey,
   sendProtobufResponse,
@@ -18,37 +17,15 @@ describe('live-track routes and helpers', () => {
   const rawData = Buffer.from('hello-live-track-data');
   const gzippedData = zlib.gzipSync(rawData);
 
-  describe('isGzip', () => {
-    it('should detect valid gzip buffers with magic header (0x1f, 0x8b)', () => {
-      expect(isGzip(gzippedData)).toBe(true);
-    });
-
-    it('should return false for uncompressed buffers', () => {
-      expect(isGzip(rawData)).toBe(false);
-    });
-
-    it('should return false for short or null/undefined buffers', () => {
-      expect(isGzip(null)).toBe(false);
-      expect(isGzip(undefined)).toBe(false);
-      expect(isGzip(Buffer.from([0x1f]))).toBe(false);
-      expect(isGzip(Buffer.alloc(0))).toBe(false);
-    });
-  });
-
-  describe('ensureDecompressed', () => {
+  describe('decompressProto', () => {
     it('should decompress gzipped buffers', () => {
-      const result = ensureDecompressed(gzippedData);
+      const result = decompressProto(gzippedData);
       expect(result).not.toBeNull();
       expect(result?.toString()).toBe('hello-live-track-data');
     });
 
-    it('should return uncompressed buffers unchanged', () => {
-      const result = ensureDecompressed(rawData);
-      expect(result).toBe(rawData);
-    });
-
     it('should return null for null input', () => {
-      expect(ensureDecompressed(null)).toBeNull();
+      expect(decompressProto(null)).toBeNull();
     });
   });
 
@@ -199,19 +176,6 @@ describe('live-track routes and helpers', () => {
 
       const { res, headers } = createMockRes();
       sendProtobufResponse(req, res, gzippedData);
-
-      expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
-      expect(headers['Content-Encoding']).toBeUndefined();
-      expect(res.send).toHaveBeenCalledWith(rawData);
-    });
-
-    it('should serve uncompressed buffer as-is', () => {
-      const req = {
-        acceptsEncodings: vi.fn((encoding: string) => (encoding === 'gzip' ? 'gzip' : false)),
-      } as unknown as Request;
-
-      const { res, headers } = createMockRes();
-      sendProtobufResponse(req, res, rawData);
 
       expect(res.set).toHaveBeenCalledWith('Content-Type', 'application/x-protobuf');
       expect(headers['Content-Encoding']).toBeUndefined();

--- a/apps/fxc-server/src/app/routes/live-track.ts
+++ b/apps/fxc-server/src/app/routes/live-track.ts
@@ -25,26 +25,13 @@ import { getUserInfo, isLoggedIn, logout } from './session';
 const csrfProtection = csurf();
 
 /**
- * Checks if the buffer starts with the standard Gzip magic bytes (0x1f, 0x8b).
+ * Decompresses a gzipped protobuf buffer from Redis.
  *
- * @param buffer - The buffer or Uint8Array to test.
- * @returns `true` if the buffer has a Gzip magic header, `false` otherwise.
+ * @param buffer - Gzip-compressed buffer from Redis.
+ * @returns Decompressed buffer, or `null` if the input was null.
  */
-export function isGzip(buffer: Buffer | Uint8Array | null | undefined): boolean {
-  return buffer != null && buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b;
-}
-
-/**
- * Decompresses a buffer if it is gzip-compressed; otherwise returns it as-is.
- *
- * @param buffer - The raw or compressed buffer from Redis.
- * @returns The uncompressed buffer, or `null` if the input was null.
- */
-export function ensureDecompressed(buffer: Buffer | null): Buffer | null {
-  if (!buffer) {
-    return null;
-  }
-  return isGzip(buffer) ? zlib.gunzipSync(buffer) : buffer;
+export function decompressProto(buffer: Buffer | null): Buffer | null {
+  return buffer ? zlib.gunzipSync(buffer) : null;
 }
 
 /**
@@ -83,14 +70,13 @@ export function resolveLiveTrackKey(
 }
 
 /**
- * Sends a protobuf buffer to the client, handling Gzip transparently:
- * - If the buffer from Redis is gzipped and the client accepts gzip, sends with `Content-Encoding: gzip` (no server CPU decompression).
- * - If the buffer from Redis is gzipped and the client does not accept gzip, decompresses on-the-fly.
- * - If the buffer from Redis is uncompressed (legacy format during migration), sends as raw protobuf.
+ * Sends a gzipped protobuf buffer to the client:
+ * - If the client accepts gzip, sends with `Content-Encoding: gzip` directly (zero server CPU decompression).
+ * - If the client does not accept gzip, decompresses on the fly.
  *
  * @param req - Express request object used to check accepted encodings.
  * @param res - Express response object.
- * @param buffer - The protobuf buffer (gzipped, raw, or null).
+ * @param buffer - The gzipped protobuf buffer (or null).
  */
 export function sendProtobufResponse(req: Request, res: Response, buffer: Buffer | null): void {
   res.set('Content-Type', 'application/x-protobuf');
@@ -100,15 +86,11 @@ export function sendProtobufResponse(req: Request, res: Response, buffer: Buffer
     return;
   }
 
-  if (isGzip(buffer)) {
-    if (req.acceptsEncodings('gzip') === 'gzip') {
-      res.set('Content-Encoding', 'gzip');
-      res.send(buffer);
-    } else {
-      res.send(zlib.gunzipSync(buffer));
-    }
-  } else {
+  if (req.acceptsEncodings('gzip') === 'gzip') {
+    res.set('Content-Encoding', 'gzip');
     res.send(buffer);
+  } else {
+    res.send(zlib.gunzipSync(buffer));
   }
 }
 
@@ -185,7 +167,7 @@ export async function handlePartnerTokenRequest(
     case SECRETS.FLYME_TOKEN: {
       const groupProto = await getCachedProto(bufferRedis, Keys.fetcherExportFlymeProto);
       if (req.header('accept') === 'application/json') {
-        const uncompressed = ensureDecompressed(groupProto);
+        const uncompressed = decompressProto(groupProto);
         const track = uncompressed
           ? protos.LiveDifferentialTrackGroup.fromBinary(uncompressed)
           : protos.LiveDifferentialTrackGroup.create();
@@ -198,7 +180,7 @@ export async function handlePartnerTokenRequest(
     case SECRETS.WING_TOKEN:
     case SECRETS.ZIPLINE_TOKEN: {
       const liveGroupProto = await getCachedProto(bufferRedis, Keys.fetcherFullProtoH12);
-      const uncompressed = ensureDecompressed(liveGroupProto);
+      const uncompressed = decompressProto(liveGroupProto);
 
       const liveGroup = uncompressed
         ? protos.LiveDifferentialTrackGroup.fromBinary(uncompressed)


### PR DESCRIPTION
## Summary by Sourcery

Assume live-track protobuf data retrieved from Redis is gzip-compressed and streamline its delivery and decoding.

Enhancements:
- Treat Redis live-track protobuf values as gzipped data and remove support for detecting or serving uncompressed legacy buffers.
- Simplify protobuf response handling to pass through gzip when accepted and decompress only when required by the client.
- Rename and narrow decompression helpers for the new Redis data contract.

Tests:
- Update live-track tests to cover the gzip-only decompression and response behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live tracking response handling for compressed protobuf data.
  - Live tracking responses now consistently support gzip delivery when accepted by the client.
  - Partner token responses are correctly decompressed before processing.
  - Requests that do not accept gzip continue to receive decompressed response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->