### PR TITLE
perf(fetcher): fetch elevation for unseen location only

### DIFF
--- a/apps/fetcher/src/app/elevation/elevation.test.ts
+++ b/apps/fetcher/src/app/elevation/elevation.test.ts
@@ -1,4 +1,4 @@
-import { NO_GROUND_ALTITUDE, type protos } from '@flyxc/common';
+import { Comparison, findFirstIndex, NO_GROUND_ALTITUDE, type protos } from '@flyxc/common';
 import type { AltitudeResult } from '@flyxc/common-node';
 import { ElevationService } from '@flyxc/common-node';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -55,7 +55,7 @@ describe('patchTracksElevation', () => {
       extra: {},
     };
 
-    const updates = await patchTracksElevation([delta1, delta2], mockElevationService);
+    const updates = await patchTracksElevation([{ track: delta1 }, { track: delta2 }], mockElevationService);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith([45.0, 45.01, 46.0], [6.0, 6.01, 7.0]);
@@ -83,7 +83,7 @@ describe('patchTracksElevation', () => {
       extra: {},
     };
 
-    const updates = await patchTracksElevation([delta], mockElevationService);
+    const updates = await patchTracksElevation([{ track: delta }], mockElevationService);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith([45.01], [6.01]);
@@ -91,6 +91,50 @@ describe('patchTracksElevation', () => {
     expect(updates.numRetrieved).toBe(1);
     expect(delta.gndAlt[0]).toBe(400);
     expect(delta.gndAlt[1]).toBe(750);
+  });
+
+  it('should only check points on or after fromSec when fromSec is provided', async () => {
+    const fetchSpy = vi.spyOn(mockElevationService, 'fetchCoordinatesAltitude').mockResolvedValue({
+      altitudes: [850],
+      hasErrors: false,
+    });
+
+    const track: protos.LiveTrack = {
+      timeSec: [100, 200, 300],
+      lat: [45.0, 45.1, 45.2],
+      lon: [6.0, 6.1, 6.2],
+      alt: [1000, 1050, 1100],
+      gndAlt: [NO_GROUND_ALTITUDE, 500, NO_GROUND_ALTITUDE],
+      flags: [0, 0, 0],
+      extra: {},
+    };
+
+    // fromSec = 200:
+    // index 0 (timeSec 100): < 200 -> ignored even though gndAlt is invalid
+    // index 1 (timeSec 200): >= 200 -> gndAlt is valid (500) -> skipped
+    // index 2 (timeSec 300): >= 200 -> gndAlt is invalid -> fetched
+    const updates = await patchTracksElevation([{ track, fromSec: 200 }], mockElevationService);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith([45.2], [6.2]);
+    expect(updates.numFetched).toBe(1);
+    expect(updates.numRetrieved).toBe(1);
+    expect(track.gndAlt[0]).toBe(NO_GROUND_ALTITUDE);
+    expect(track.gndAlt[1]).toBe(500);
+    expect(track.gndAlt[2]).toBe(850);
+  });
+
+  it('should find the first index greater or equal correctly', () => {
+    const arr = [100, 200, 300];
+    const opts = { comparison: Comparison.GREATER_EQUAL };
+    expect(findFirstIndex(arr, 50, opts)).toBe(0);
+    expect(findFirstIndex(arr, 100, opts)).toBe(0);
+    expect(findFirstIndex(arr, 150, opts)).toBe(1);
+    expect(findFirstIndex(arr, 200, opts)).toBe(1);
+    expect(findFirstIndex(arr, 250, opts)).toBe(2);
+    expect(findFirstIndex(arr, 300, opts)).toBe(2);
+    expect(findFirstIndex(arr, 350, opts)).toBe(3);
+    expect(findFirstIndex([], 100, opts)).toBe(0);
   });
 
   it('handles errors gracefully', async () => {
@@ -109,7 +153,7 @@ describe('patchTracksElevation', () => {
       extra: {},
     };
 
-    const updates = await patchTracksElevation([delta], mockElevationService);
+    const updates = await patchTracksElevation([{ track: delta }], mockElevationService);
 
     expect(updates.numFetched).toBe(1);
     expect(updates.numRetrieved).toBe(0);
@@ -134,7 +178,7 @@ describe('patchTracksElevation', () => {
       extra: {},
     };
 
-    const updates = await patchTracksElevation([delta], mockElevationService);
+    const updates = await patchTracksElevation([{ track: delta }], mockElevationService);
 
     expect(fetchSpy).toHaveBeenCalledWith([45.0], [6.0]);
     expect(updates.numFetched).toBe(1);
@@ -160,7 +204,7 @@ describe('patchTracksElevation', () => {
         return { altitudes: [500], hasErrors: false };
       });
 
-      const promise = patchTracksElevation([delta], mockElevationService);
+      const promise = patchTracksElevation([{ track: delta }], mockElevationService);
       await vi.runAllTimersAsync();
       const updates = await promise;
 
@@ -186,7 +230,7 @@ describe('patchTracksElevation', () => {
       extra: {},
     };
 
-    const updates = await patchTracksElevation([delta], mockElevationService);
+    const updates = await patchTracksElevation([{ track: delta }], mockElevationService);
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(updates.numFetched).toBe(ELEVATION_BATCH_SIZE + 10);
@@ -212,7 +256,7 @@ describe('patchTracksElevation', () => {
         return { altitudes: new Array(ELEVATION_BATCH_SIZE).fill(500), hasErrors: false };
       });
 
-      const promise = patchTracksElevation([delta], mockElevationService);
+      const promise = patchTracksElevation([{ track: delta }], mockElevationService);
       await vi.runAllTimersAsync();
       const updates = await promise;
 

--- a/apps/fetcher/src/app/elevation/elevation.ts
+++ b/apps/fetcher/src/app/elevation/elevation.ts
@@ -1,4 +1,4 @@
-import { isGroundAltitudeValid, NO_GROUND_ALTITUDE, type protos } from '@flyxc/common';
+import { Comparison, findFirstIndex, isGroundAltitudeValid, NO_GROUND_ALTITUDE, type protos } from '@flyxc/common';
 import { type ElevationCacheStats, ElevationService } from '@flyxc/common-node';
 
 export interface ElevationUpdates {
@@ -21,18 +21,23 @@ export const ELEVATION_FETCH_TIMEOUT_MS = 10_000;
 
 const defaultElevationService = new ElevationService({ cacheSizeMb: 50, zoom: 10 });
 
+export interface TrackElevationPatch {
+  track: protos.LiveTrack;
+  fromSec?: number;
+}
+
 /**
- * Populates ground altitudes for newly added points in update tracks (deltas).
+ * Populates ground altitudes for newly added points in tracks.
  *
  * Missing points across all tracks are batched in chunks of up to ELEVATION_BATCH_SIZE.
  * After each batch, execution time is checked against ELEVATION_FETCH_TIMEOUT_MS to stop early.
  *
- * @param tracks - Update tracks containing points from the current cycle.
+ * @param tracks - Tracks or patch objects with optional `fromSec` timestamp.
  * @param elevationService - Elevation service instance (defaults to shared module instance).
  * @returns Summary of fetched points, retrieved elevations, duration, and errors.
  */
 export async function patchTracksElevation(
-  tracks: Iterable<protos.LiveTrack>,
+  tracks: Iterable<TrackElevationPatch>,
   elevationService = defaultElevationService,
 ): Promise<ElevationUpdates> {
   const startMs = Date.now();
@@ -53,7 +58,7 @@ export async function patchTracksElevation(
   const allLats: number[] = [];
   const allLons: number[] = [];
 
-  for (const track of tracks) {
+  for (const { track, fromSec } of tracks) {
     if (!track || track.lat.length === 0) {
       continue;
     }
@@ -62,7 +67,12 @@ export async function patchTracksElevation(
       track.gndAlt = Array(track.lat.length).fill(NO_GROUND_ALTITUDE);
     }
 
-    for (let i = 0; i < track.lat.length; i++) {
+    const startIdx =
+      fromSec != null && track.timeSec?.length > 0
+        ? findFirstIndex(track.timeSec, fromSec, { comparison: Comparison.GREATER_EQUAL })
+        : 0;
+
+    for (let i = startIdx; i < track.lat.length; i++) {
       if (!isGroundAltitudeValid(track.gndAlt[i])) {
         targets.push({ track, idx: i });
         allLats.push(track.lat[i]);

--- a/apps/fetcher/src/app/trackers/flymaster.ts
+++ b/apps/fetcher/src/app/trackers/flymaster.ts
@@ -78,7 +78,7 @@ export class FlymasterFetcher extends TrackerFetcher {
         // Get an extra 5min of data that might not have been received (when no network coverage).
         const points = parse(flight);
         let track = makeLiveTrack(points);
-        track = removeBeforeFromLiveTrack(track, fetchSecond - 300);
+        track = removeBeforeFromLiveTrack(track, fetchSecond - 5 * 60);
         simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
         updates.trackerDeltas.set(dsId, track);
       }

--- a/apps/fetcher/src/app/trackers/refresh.test.ts
+++ b/apps/fetcher/src/app/trackers/refresh.test.ts
@@ -71,7 +71,7 @@ describe('applyTrackerUpdates', () => {
 
     const updatedIds = applyTrackerUpdates(state, [updates], nowSec);
 
-    expect(updatedIds).toEqual(new Set([1]));
+    expect(updatedIds).toEqual(new Map([[1, nowSec - 30]]));
 
     // Pilot 1 was updated: delta merged and simplified
     // Points within intervalSec (5s) are decimated:
@@ -83,6 +83,73 @@ describe('applyTrackerUpdates', () => {
 
     // Pilot 3 had no updates: track remains empty
     expect(state.pilots[3].track.timeSec).toEqual([]);
+  });
+
+  it('should record the earliest timestamp when multiple patches update the same pilot', () => {
+    const nowSec = 1700000000;
+    const pilot1Track: protos.LiveTrack = {
+      timeSec: [nowSec - 200],
+      lat: [45.0],
+      lon: [6.0],
+      alt: [1000],
+      gndAlt: [500],
+      flags: [0],
+      extra: {},
+    };
+    const state = protos.FetcherState.create({
+      pilots: {
+        1: { track: pilot1Track },
+      },
+    });
+
+    const update1: TrackerUpdates = {
+      name: 'inreach',
+      trackerDeltas: new Map([
+        [
+          1,
+          {
+            timeSec: [nowSec - 50, nowSec - 30],
+            lat: [45.1, 45.2],
+            lon: [6.1, 6.2],
+            alt: [1050, 1060],
+            gndAlt: [0, 0],
+            flags: [0, 0],
+            extra: {},
+          },
+        ],
+      ]),
+      trackerErrors: new Map(),
+      errors: [],
+      fetchedTracker: new Set([1]),
+      startFetchSec: nowSec - 5,
+      endFetchSec: nowSec,
+    };
+
+    const update2: TrackerUpdates = {
+      name: 'ogn',
+      trackerDeltas: new Map([
+        [
+          1,
+          {
+            timeSec: [nowSec - 80, nowSec - 40],
+            lat: [45.05, 45.15],
+            lon: [6.05, 6.15],
+            alt: [1020, 1055],
+            gndAlt: [0, 0],
+            flags: [0, 0],
+            extra: {},
+          },
+        ],
+      ]),
+      trackerErrors: new Map(),
+      errors: [],
+      fetchedTracker: new Set([1]),
+      startFetchSec: nowSec - 5,
+      endFetchSec: nowSec,
+    };
+
+    const updatedPilots = applyTrackerUpdates(state, [update1, update2], nowSec);
+    expect(updatedPilots).toEqual(new Map([[1, nowSec - 80]]));
   });
 
   it('should drop outdated points (> 48h) for non-updated pilots', () => {

--- a/apps/fetcher/src/app/trackers/refresh.ts
+++ b/apps/fetcher/src/app/trackers/refresh.ts
@@ -12,7 +12,7 @@ import type { RedisClient, RedisClientMultiCmd } from '@flyxc/common-node';
 import { pushListCap } from '@flyxc/common-node';
 import type { Datastore } from '@google-cloud/datastore';
 
-import { patchTracksElevation } from '../elevation/elevation';
+import { patchTracksElevation, type TrackElevationPatch } from '../elevation/elevation';
 import { addElevationLogs } from '../redis';
 import { FlymasterFetcher } from './flymaster';
 import { FlymeFetcher } from './flyme';
@@ -80,18 +80,19 @@ export async function resfreshTrackers(
     }
   }
 
+  const nowSec = Math.round(Date.now() / 1000);
+  const updatedPilots = applyTrackerUpdates(state, trackerUpdates, nowSec);
+
   // Fetch ground elevation for newly added points in tracker updates.
-  const deltas: protos.LiveTrack[] = [];
-  for (const updates of trackerUpdates) {
-    for (const delta of updates.trackerDeltas.values()) {
-      deltas.push(delta);
+  const tracksToPatch: TrackElevationPatch[] = [];
+  for (const [id, fromSec] of updatedPilots) {
+    const pilot = state.pilots[id];
+    if (pilot?.track) {
+      tracksToPatch.push({ track: pilot.track, fromSec });
     }
   }
-  const elevationUpdates = await patchTracksElevation(deltas);
+  const elevationUpdates = await patchTracksElevation(tracksToPatch);
   addElevationLogs(pipeline, elevationUpdates, state.lastTickSec);
-
-  const nowSec = Math.round(Date.now() / 1000);
-  applyTrackerUpdates(state, trackerUpdates, nowSec);
 }
 
 /**
@@ -103,22 +104,28 @@ export async function resfreshTrackers(
  * @param state - The FetcherState object containing current state information.
  * @param trackerUpdates - Array of updates from tracker fetches.
  * @param nowSec - Current timestamp in seconds (defaults to now).
+ * @returns Map of updated pilot IDs to their earliest patch timestamp in seconds.
  */
 export function applyTrackerUpdates(
   state: protos.FetcherState,
   trackerUpdates: TrackerUpdates[],
   nowSec = Math.round(Date.now() / 1000),
-): Set<number> {
+): Map<number, number> {
   const dropBeforeSec = nowSec - LiveDataRetentionSec.Max;
 
   // Merge updates only for pilots that have deltas in this cycle.
-  const updatedPilotIds = new Set<number>();
+  // Record the earliest timestamp of all patches for each updated pilot.
+  const updatedPilots = new Map<number, number>();
   for (const updates of trackerUpdates) {
     for (const [id, delta] of updates.trackerDeltas.entries()) {
       const pilot = state.pilots[id];
       if (pilot) {
         pilot.track = mergeLiveTracks(pilot.track, delta);
-        updatedPilotIds.add(id);
+        if (delta.timeSec.length > 0) {
+          const deltaMinSec = delta.timeSec[0];
+          const currentMinSec = updatedPilots.get(id);
+          updatedPilots.set(id, currentMinSec != null ? Math.min(currentMinSec, deltaMinSec) : deltaMinSec);
+        }
       }
     }
   }
@@ -126,13 +133,11 @@ export function applyTrackerUpdates(
   // Drop points older than max retention for all tracks that have outdated points.
   for (const id in state.pilots) {
     const pilot = state.pilots[id];
-    if (pilot.track.timeSec.length > 0 && pilot.track.timeSec[0] < dropBeforeSec) {
-      pilot.track = removeBeforeFromLiveTrack(pilot.track, dropBeforeSec);
-    }
+    pilot.track = removeBeforeFromLiveTrack(pilot.track, dropBeforeSec);
   }
 
   // Only simplify and decimate tracks for pilots that were updated in the current cycle.
-  for (const id of updatedPilotIds) {
+  for (const id of updatedPilots.keys()) {
     const pilot = state.pilots[id];
     if (pilot) {
       simplifyLiveTrack(pilot.track, LiveDataIntervalSec.AfterH24, {
@@ -151,7 +156,7 @@ export function applyTrackerUpdates(
       });
     }
   }
-  return updatedPilotIds;
+  return updatedPilots;
 }
 
 /**

--- a/apps/fetcher/src/app/trackers/skylines.ts
+++ b/apps/fetcher/src/app/trackers/skylines.ts
@@ -57,7 +57,7 @@ export class SkylinesFetcher extends TrackerFetcher {
               const sklId = Number(flight.sfid);
               const dsId = sklIdToDsId.get(sklId) as number;
               // Get an extra 10min of data that might not have been received (when no network coverage).
-              const keepFromSec = this.getTrackerFetchFromSec(dsId, updates.startFetchSec, 600);
+              const keepFromSec = this.getTrackerFetchFromSec(dsId, updates.startFetchSec, 10 * 60);
               const points = parse(flight);
               let track = makeLiveTrack(points);
               track = removeBeforeFromLiveTrack(track, keepFromSec);

--- a/apps/fetcher/src/app/trackers/zoleo.ts
+++ b/apps/fetcher/src/app/trackers/zoleo.ts
@@ -23,8 +23,7 @@ export class ZoleoFetcher extends TrackerFetcher {
     return 'zoleo';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected async fetch(devices: number[], updates: TrackerUpdates, timeoutSec: number): Promise<void> {
+  protected async fetch(devices: number[], updates: TrackerUpdates, _timeoutSec: number): Promise<void> {
     const messages = (await flushMessageQueue(this.redis)).filter((m) => m != null);
 
     if (messages.length == 0) {

--- a/libs/common/src/lib/live-track.test.ts
+++ b/libs/common/src/lib/live-track.test.ts
@@ -2,7 +2,6 @@ import { LiveTrack } from '../protos/live-track';
 import {
   differentialDecodeLiveTrack,
   differentialEncodeLiveTrack,
-  findLastIndexLessOrEqual,
   getLastMessage,
   isEmergencyTrack,
   IsSimplifiableFix,
@@ -703,55 +702,6 @@ describe('simplifyLiveTrack', () => {
     } as any;
     simplifyLiveTrack(track, 10);
     expect(track.gndAlt).toEqual([NO_GROUND_ALTITUDE, NO_GROUND_ALTITUDE]);
-  });
-});
-
-describe('findLastIndexLessOrEqual', () => {
-  it('should return -1 for an empty array', () => {
-    expect(findLastIndexLessOrEqual([], 10)).toBe(-1);
-  });
-
-  it('should handle single element arrays', () => {
-    expect(findLastIndexLessOrEqual([10], 5)).toBe(-1);
-    expect(findLastIndexLessOrEqual([10], 10)).toBe(0);
-    expect(findLastIndexLessOrEqual([10], 15)).toBe(0);
-  });
-
-  it('should return -1 when value is less than the first element', () => {
-    expect(findLastIndexLessOrEqual([10, 20, 30], 5)).toBe(-1);
-    expect(findLastIndexLessOrEqual([10, 20, 30], 9)).toBe(-1);
-  });
-
-  it('should return 0 when value equals the first element', () => {
-    expect(findLastIndexLessOrEqual([10, 20, 30], 10)).toBe(0);
-  });
-
-  it('should find exact matches in sorted array', () => {
-    const list = [10, 20, 30, 40, 50];
-    expect(findLastIndexLessOrEqual(list, 20)).toBe(1);
-    expect(findLastIndexLessOrEqual(list, 30)).toBe(2);
-    expect(findLastIndexLessOrEqual(list, 40)).toBe(3);
-    expect(findLastIndexLessOrEqual(list, 50)).toBe(4);
-  });
-
-  it('should find the largest index less than value when not an exact match', () => {
-    const list = [10, 20, 30, 40, 50];
-    expect(findLastIndexLessOrEqual(list, 15)).toBe(0);
-    expect(findLastIndexLessOrEqual(list, 25)).toBe(1);
-    expect(findLastIndexLessOrEqual(list, 39)).toBe(2);
-    expect(findLastIndexLessOrEqual(list, 49)).toBe(3);
-  });
-
-  it('should return len - 1 when value is greater than the last element', () => {
-    const list = [10, 20, 30, 40, 50];
-    expect(findLastIndexLessOrEqual(list, 55)).toBe(4);
-    expect(findLastIndexLessOrEqual(list, 1000)).toBe(4);
-  });
-
-  it('should handle duplicate values returning the last matching index', () => {
-    const list = [10, 20, 20, 20, 30];
-    expect(findLastIndexLessOrEqual(list, 20)).toBe(3);
-    expect(findLastIndexLessOrEqual(list, 25)).toBe(3);
   });
 });
 

--- a/libs/common/src/lib/live-track.ts
+++ b/libs/common/src/lib/live-track.ts
@@ -1,6 +1,8 @@
 import type { LiveDifferentialTrack, LiveExtra } from '../protos/live-track';
 import { LiveTrack } from '../protos/live-track';
-import { diffDecodeArray, diffEncodeArray32bit, findIndexes } from './math';
+import { Comparison, diffDecodeArray, diffEncodeArray32bit, findFirstIndex } from './math';
+
+export { Comparison, findFirstIndex } from './math';
 
 // Number of bits reserved for device names.
 const DEVICE_TYPE_NUM_BITS = 5;
@@ -247,8 +249,7 @@ export function removeBeforeFromLiveTrack(track: LiveTrack, timeSec: number): Li
   }
 
   // Find the first index whose time is >= timeSec.
-  const indexes = findIndexes(track.timeSec, timeSec);
-  const numToDelete = indexes.afterIndex;
+  const numToDelete = findFirstIndex(track.timeSec, timeSec, { comparison: Comparison.GREATER_EQUAL });
 
   const extra: { [key: string]: LiveExtra } = {};
   for (const index in track.extra) {
@@ -287,34 +288,6 @@ export function removeDeviceFromLiveTrack(track: LiveTrack, device: TrackerNames
   }
 
   return outTrack;
-}
-
-/**
- * Finds the largest index where ascendingList[i] <= value using binary search.
- *
- * @param ascendingList - List of numbers in ascending order.
- * @param value - Search value.
- * @returns The largest index where ascendingList[i] <= value, or -1 if value is less than the first element.
- */
-export function findLastIndexLessOrEqual(ascendingList: number[], value: number): number {
-  const len = ascendingList.length;
-  if (len === 0 || value < ascendingList[0]) {
-    return -1;
-  }
-  if (value >= ascendingList[len - 1]) {
-    return len - 1;
-  }
-  let low = 0;
-  let high = len - 1;
-  while (low < high) {
-    const mid = (low + high + 1) >> 1;
-    if (ascendingList[mid] <= value) {
-      low = mid;
-    } else {
-      high = mid - 1;
-    }
-  }
-  return low;
 }
 
 /**
@@ -390,13 +363,13 @@ export function simplifyLiveTrack(
     if (fromSec > lastTime) {
       return;
     }
-    const idx = findLastIndexLessOrEqual(timeSecs, fromSec);
+    const idx = findFirstIndex(timeSecs, fromSec, { comparison: Comparison.GREATER }) - 1;
     startIndex = Math.max(0, idx);
   }
 
   let simplifyUntilIndex = len - 1;
   if (time?.toSec != null) {
-    const idx = findLastIndexLessOrEqual(timeSecs, time.toSec);
+    const idx = findFirstIndex(timeSecs, time.toSec, { comparison: Comparison.GREATER }) - 1;
     if (idx < 0) {
       return;
     }

--- a/libs/common/src/lib/math.test.ts
+++ b/libs/common/src/lib/math.test.ts
@@ -1,4 +1,4 @@
-import { diffDecodeArray, diffEncodeArray32bit, findIndexes } from './math';
+import { Comparison, diffDecodeArray, diffEncodeArray32bit, findFirstIndex, findIndexes } from './math';
 
 describe('findIndexes', () => {
   test('throws when the lis is empty', () => {
@@ -130,5 +130,70 @@ describe('diffDecodeArray', () => {
     for (let i = 0; i < original.length; i++) {
       expect(decoded[i]).toBeCloseTo(original[i], 5);
     }
+  });
+});
+
+describe('findFirstIndex', () => {
+  describe('Comparison.GREATER_EQUAL', () => {
+    const opts = { comparison: Comparison.GREATER_EQUAL };
+
+    it('should return 0 for empty arrays', () => {
+      expect(findFirstIndex([], 100, opts)).toBe(0);
+    });
+
+    it('should handle single element arrays', () => {
+      expect(findFirstIndex([10], 5, opts)).toBe(0);
+      expect(findFirstIndex([10], 10, opts)).toBe(0);
+      expect(findFirstIndex([10], 15, opts)).toBe(1);
+    });
+
+    it('should find lower bound in multi-element arrays', () => {
+      const arr = [100, 200, 300];
+      expect(findFirstIndex(arr, 50, opts)).toBe(0);
+      expect(findFirstIndex(arr, 100, opts)).toBe(0);
+      expect(findFirstIndex(arr, 150, opts)).toBe(1);
+      expect(findFirstIndex(arr, 200, opts)).toBe(1);
+      expect(findFirstIndex(arr, 250, opts)).toBe(2);
+      expect(findFirstIndex(arr, 300, opts)).toBe(2);
+      expect(findFirstIndex(arr, 350, opts)).toBe(3);
+    });
+
+    it('should return first index when duplicate values exist', () => {
+      const arr = [10, 20, 20, 20, 30];
+      expect(findFirstIndex(arr, 20, opts)).toBe(1);
+    });
+  });
+
+  describe('Comparison.GREATER', () => {
+    const opts = { comparison: Comparison.GREATER };
+
+    it('should return 0 for empty arrays', () => {
+      expect(findFirstIndex([], 100, opts)).toBe(0);
+    });
+
+    it('should handle single element arrays', () => {
+      expect(findFirstIndex([10], 5, opts)).toBe(0);
+      expect(findFirstIndex([10], 10, opts)).toBe(1);
+      expect(findFirstIndex([10], 15, opts)).toBe(1);
+    });
+
+    it('should find upper bound in multi-element arrays', () => {
+      const list = [10, 20, 30, 40, 50];
+      expect(findFirstIndex(list, 5, opts)).toBe(0);
+      expect(findFirstIndex(list, 10, opts)).toBe(1);
+      expect(findFirstIndex(list, 15, opts)).toBe(1);
+      expect(findFirstIndex(list, 20, opts)).toBe(2);
+      expect(findFirstIndex(list, 25, opts)).toBe(2);
+      expect(findFirstIndex(list, 30, opts)).toBe(3);
+      expect(findFirstIndex(list, 40, opts)).toBe(4);
+      expect(findFirstIndex(list, 50, opts)).toBe(5);
+      expect(findFirstIndex(list, 55, opts)).toBe(5);
+    });
+
+    it('should return index after duplicates when duplicate values exist', () => {
+      const list = [10, 20, 20, 20, 30];
+      expect(findFirstIndex(list, 20, opts)).toBe(4);
+      expect(findFirstIndex(list, 25, opts)).toBe(4);
+    });
   });
 });

--- a/libs/common/src/lib/math.ts
+++ b/libs/common/src/lib/math.ts
@@ -29,18 +29,67 @@ export function sampleAt(xs: number[], ys: number[], targetX: number): number {
   return linearInterpolate(xs[beforeIndex], ys[beforeIndex], xs[afterIndex], ys[afterIndex], targetX);
 }
 
-// Finds the two indexes left and right of the value.
-//
-// The output contains the following properties:
-// - beforeAll: true when the value is less than any element in the list,
-// - beforeIndex and afterIndex: indexes before and after the value. They are equal to the index of the value when
-//   it is in the list.
-// - afterAll: true when the value is greater than any element in the list.
+export const enum Comparison {
+  GREATER,
+  GREATER_EQUAL,
+}
+
+/**
+ * Binary search to find the partition point in an ascending array.
+ *
+ * @param ascendingList - List of numbers in ascending order.
+ * @param value - Search value.
+ * @param options - Search options specifying Comparison.GREATER (>) or Comparison.GREATER_EQUAL (>=).
+ * @returns Index in [0, ascendingList.length].
+ */
+export function findFirstIndex(ascendingList: number[], value: number, options: { comparison: Comparison }): number {
+  const len = ascendingList.length;
+  if (len === 0) {
+    return 0;
+  }
+  const isGreater = options.comparison === Comparison.GREATER;
+  const first = ascendingList[0];
+  if (isGreater ? first > value : first >= value) {
+    return 0;
+  }
+  const last = ascendingList[len - 1];
+  if (isGreater ? last <= value : last < value) {
+    return len;
+  }
+
+  let low = 0;
+  let high = len - 1;
+  let result = len;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (isGreater ? ascendingList[mid] > value : ascendingList[mid] >= value) {
+      result = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return result;
+}
+
+/**
+ * Finds the two indexes left and right of the value in an ascending list.
+ *
+ * The output contains the following properties:
+ * - beforeAll: true when the value is less than any element in the list,
+ * - beforeIndex and afterIndex: indexes before and after the value. They are equal to the index of the value when
+ *   it is in the list.
+ * - afterAll: true when the value is greater than any element in the list.
+ *
+ * @param ascendingList - List of numbers in ascending order (must not be empty).
+ * @param value - Search value.
+ */
 export function findIndexes(
   ascendingList: number[],
   value: number,
 ): { beforeAll: boolean; afterAll: boolean; beforeIndex: number; afterIndex: number } {
-  if (ascendingList.length == 0) {
+  const len = ascendingList.length;
+  if (len === 0) {
     throw new Error('The list must contain at least 1 element');
   }
 
@@ -53,48 +102,23 @@ export function findIndexes(
     };
   }
 
-  let afterIndex = ascendingList.length - 1;
-
-  if (value > ascendingList[ascendingList.length - 1]) {
+  if (value > ascendingList[len - 1]) {
     return {
       beforeAll: false,
-      beforeIndex: afterIndex,
+      beforeIndex: len - 1,
       afterAll: true,
-      afterIndex: afterIndex,
+      afterIndex: len - 1,
     };
   }
 
-  if (afterIndex == 0) {
-    return {
-      beforeAll: false,
-      beforeIndex: 0,
-      afterAll: false,
-      afterIndex: 0,
-    };
-  }
-
-  let beforeIndex = 0;
-
-  while (afterIndex - beforeIndex > 1) {
-    const m = Math.round((beforeIndex + afterIndex) / 2);
-    if (ascendingList[m] > value) {
-      afterIndex = m;
-    } else {
-      beforeIndex = m;
-    }
-  }
-
-  if (ascendingList[afterIndex - 1] == value) {
-    afterIndex = afterIndex - 1;
-  } else if (ascendingList[beforeIndex + 1] == value) {
-    beforeIndex = beforeIndex + 1;
-  }
+  const idx = findFirstIndex(ascendingList, value, { comparison: Comparison.GREATER }) - 1;
+  const isExact = ascendingList[idx] === value;
 
   return {
     beforeAll: false,
-    afterIndex,
+    beforeIndex: idx,
     afterAll: false,
-    beforeIndex,
+    afterIndex: isExact ? idx : idx + 1,
   };
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Fetch elevation only for unseen points while preserving the earliest update boundary across merged tracker updates.

Bug Fixes:
- Restrict elevation lookups to newly added or otherwise unseen track points, avoiding redundant fetches for previously processed locations.

Enhancements:
- Track the earliest update timestamp per pilot so merged tracker patches can be selectively processed for elevation.
- Consolidate ascending-array partition searches into a reusable binary-search utility supporting greater-than and greater-than-or-equal comparisons.
- Update live-track trimming and simplification to use the shared search utility.

Tests:
- Add coverage for timestamp-scoped elevation fetching, earliest timestamps across multiple tracker patches, and binary-search boundary and duplicate-value behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved elevation updates for live tracks by processing only points at or after the relevant update time.
  - Tracker refreshes now preserve the earliest update timestamp when multiple updates affect the same pilot.
  - Outdated track points are consistently removed during tracker updates.
  - Improved handling of elevation data when valid and invalid altitude points occur across update boundaries.

- **Refactor**
  - Standardized timestamp boundary handling for more consistent track filtering and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->