### PR TITLE
refactor(fetcher): wait for proxy to accept requests

### DIFF
--- a/apps/fetcher/src/app/trackers/inreach.ts
+++ b/apps/fetcher/src/app/trackers/inreach.ts
@@ -38,85 +38,90 @@ export class InreachFetcher extends TrackerFetcher {
   protected async fetch(devices: number[], updates: TrackerUpdates, timeoutSec: number): Promise<void> {
     const useProxy = Date.now() / 1000 < useProxyUntilS;
     let isRateLimited = false;
+    let fetchTrackers = true;
 
-    // When no longer rate-limited, detach the active proxy and trigger immediate
-    // zombie cleanup to terminate the unused GCE VM.
-    if (!useProxy && proxies.detachCurrent()) {
+    if (useProxy) {
+      fetchTrackers = await proxies.isReadyOrStart();
+      if (!fetchTrackers) {
+        updates.errors.push('Proxy unreachable');
+      }
+    } else if (proxies.detachCurrent()) {
+      // When no longer rate-limited, detach the active proxy and trigger immediate
+      // zombie cleanup to terminate the unused GCE VM.
       checkProxyZombiesAfterS = 0;
     }
 
-    const fetchSingle = async (id: number): Promise<void> => {
-      if (isRateLimited) {
-        return;
-      }
-      if (useProxy && !proxies.isReadyOrStart()) {
-        return;
-      }
-
-      const tracker = this.getTracker(id);
-      if (tracker == null) {
-        return;
-      }
-      if (validateInreachAccount(tracker.account) === false) {
-        updates.trackerErrors.set(id, `Invalid account ${tracker.account}`);
-        return;
-      }
-
-      const fetchFromSec = this.getTrackerFetchFromSec(id, updates.startFetchSec, 2 * 3600);
-      const url = `${tracker.account}?d1=${new Date(fetchFromSec * 1000).toISOString()}`;
-
-      try {
-        updates.fetchedTracker.add(id);
-        const dispatcher = useProxy ? proxies.getDispatcher() : undefined;
-
-        // When routing via proxy dispatcher, use Undici's own `fetch` instead of Node's `globalThis.fetch`.
-        // Node embeds its own internal copy of Undici which can drift in major versions from the npm `undici`
-        // package (e.g. when Node is upgraded in Docker while dependencies are pinned, or vice-versa).
-        // Since both `undici.fetch` and `ProxyAgent` originate from the exact same npm package, their internal
-        // dispatcher interface (e.g. `onRequestStart`) is guaranteed to match regardless of the host Node version.
-        const response = await fetchResponse(url, {
-          retry: 1,
-          timeoutS: 8,
-          dispatcher,
-          fetch: dispatcher ? (undiciFetch as any) : undefined,
-        });
-        if (response.ok) {
-          try {
-            const points = parse(await response.text());
-            const track = makeLiveTrack(points);
-            simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
-            if (track.timeSec.length > 0) {
-              updates.trackerDeltas.set(id, track);
-            }
-          } catch (e) {
-            updates.trackerErrors.set(id, `Error parsing the kml for ${id}\n${e}`);
-          }
-        } else {
-          updates.trackerErrors.set(id, `HTTP Status = ${response.status} for ${url}`);
-          if (response.status == 429) {
-            if (!isRateLimited && !useProxy) {
-              // Only update `proxyUntilS` for the main server.
-              useProxyUntilS = parseRetryAfterS(response.headers.get('Retry-After') ?? '600');
-            }
-            isRateLimited = true;
-            return;
-          }
+    if (fetchTrackers) {
+      const fetchSingle = async (id: number): Promise<void> => {
+        if (isRateLimited) {
+          return;
         }
-      } catch (e) {
-        updates.trackerErrors.set(id, `Error ${formatReqError(e)} for url ${url}`);
+
+        const tracker = this.getTracker(id);
+        if (tracker == null) {
+          return;
+        }
+        if (validateInreachAccount(tracker.account) === false) {
+          updates.trackerErrors.set(id, `Invalid account ${tracker.account}`);
+          return;
+        }
+
+        const fetchFromSec = this.getTrackerFetchFromSec(id, updates.startFetchSec, 2 * 3600);
+        const url = `${tracker.account}?d1=${new Date(fetchFromSec * 1000).toISOString()}`;
+
+        try {
+          updates.fetchedTracker.add(id);
+          const dispatcher = useProxy ? proxies.getDispatcher() : undefined;
+
+          // When routing via proxy dispatcher, use Undici's own `fetch` instead of Node's `globalThis.fetch`.
+          // Node embeds its own internal copy of Undici which can drift in major versions from the npm `undici`
+          // package (e.g. when Node is upgraded in Docker while dependencies are pinned, or vice-versa).
+          // Since both `undici.fetch` and `ProxyAgent` originate from the exact same npm package, their internal
+          // dispatcher interface (e.g. `onRequestStart`) is guaranteed to match regardless of the host Node version.
+          const response = await fetchResponse(url, {
+            retry: 1,
+            timeoutS: 8,
+            dispatcher,
+            fetch: dispatcher ? (undiciFetch as any) : undefined,
+          });
+          if (response.ok) {
+            try {
+              const points = parse(await response.text());
+              const track = makeLiveTrack(points);
+              simplifyLiveTrack(track, LiveDataIntervalSec.Recent);
+              if (track.timeSec.length > 0) {
+                updates.trackerDeltas.set(id, track);
+              }
+            } catch (e) {
+              updates.trackerErrors.set(id, `Error parsing the kml for ${id}\n${e}`);
+            }
+          } else {
+            updates.trackerErrors.set(id, `HTTP Status = ${response.status} for ${url}`);
+            if (response.status == 429) {
+              if (!isRateLimited && !useProxy) {
+                // Only update `proxyUntilS` for the main server.
+                useProxyUntilS = parseRetryAfterS(response.headers.get('Retry-After') ?? '600');
+              }
+              isRateLimited = true;
+              return;
+            }
+          }
+        } catch (e) {
+          updates.trackerErrors.set(id, `Error ${formatReqError(e)} for url ${url}`);
+        }
+      };
+
+      const { isTimeout } = await parallelTasksWithTimeout(4, devices, fetchSingle, timeoutSec * 1000);
+
+      if (isTimeout) {
+        updates.errors.push(`Fetch timeout`);
       }
-    };
 
-    const { isTimeout } = await parallelTasksWithTimeout(4, devices, fetchSingle, timeoutSec * 1000);
-
-    if (isTimeout) {
-      updates.errors.push(`Fetch timeout`);
-    }
-
-    if (isRateLimited) {
-      // Start another proxy when the current server is rate-limited.
-      proxies.start();
-      checkProxyZombiesAfterS = 0;
+      if (isRateLimited) {
+        // Start another proxy when the current server is rate-limited.
+        proxies.start();
+        checkProxyZombiesAfterS = 0;
+      }
     }
 
     if (Date.now() / 1000 > checkProxyZombiesAfterS) {

--- a/apps/fetcher/src/app/trackers/proxy.test.ts
+++ b/apps/fetcher/src/app/trackers/proxy.test.ts
@@ -1,3 +1,5 @@
+import net from 'node:net';
+
 import { fetch as undiciFetch, ProxyAgent } from 'undici';
 import undiciPkg from 'undici/package.json';
 import { describe, expect, it } from 'vitest';
@@ -42,5 +44,133 @@ describe('Proxy & Dispatcher compatibility', () => {
       expect(e?.cause?.name).not.toBe('InvalidArgumentError');
       expect(e?.cause?.message).not.toMatch(/onRequestStart/i);
     }
+  });
+
+  describe('isReadyOrStart & TCP readiness probe', () => {
+    it('returns false when proxy is not started and triggers start()', async () => {
+      const proxy = new Proxy('inreach');
+      const startSpy = vi.spyOn(proxy, 'start').mockResolvedValue(undefined);
+      const ready = await proxy.isReadyOrStart();
+      expect(ready).toBe(false);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when proxy name is set but IP is null', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-20260909-120000';
+      (proxy as any).ip = null;
+      const ready = await proxy.isReadyOrStart();
+      expect(ready).toBe(false);
+    });
+
+    it('delegates to checkProxyReady and returns false when proxy is not ready', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-20260909-120000';
+      (proxy as any).ip = '127.0.0.1';
+
+      const checkProxyReadySpy = vi.spyOn(proxy as any, 'checkProxyReady').mockResolvedValue(false);
+
+      const ready = await proxy.isReadyOrStart();
+      expect(ready).toBe(false);
+      expect(checkProxyReadySpy).toHaveBeenCalled();
+    });
+
+    it('returns true, caches isReady, and enables dispatcher when port 80 connects', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-20260909-120000';
+      (proxy as any).ip = '127.0.0.1';
+
+      const checkProxyReadySpy = vi.spyOn(proxy as any, 'checkProxyReady').mockImplementation(async () => {
+        (proxy as any).isReady = true;
+        return true;
+      });
+
+      const ready = await proxy.isReadyOrStart();
+      expect(ready).toBe(true);
+      expect(proxy.getDispatcher()).toBeDefined();
+      expect(proxy.flushLogs()).toEqual([]);
+
+      // Subsequent call should return true from cache without calling checkProxyReady again
+      expect(await proxy.isReadyOrStart()).toBe(true);
+      expect(checkProxyReadySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('checkProxyReady accurately verifies real TCP connectivity and updates isReady', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-20260909-120000';
+      (proxy as any).ip = '127.0.0.1';
+
+      // Test against an open local port
+      const server = net.createServer();
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+      const port = (server.address() as net.AddressInfo).port;
+
+      try {
+        expect(await (proxy as any).checkProxyReady(port, 500)).toBe(true);
+        expect((proxy as any).isReady).toBe(true);
+      } finally {
+        server.close();
+      }
+
+      // Test against a closed local port
+      expect(await (proxy as any).checkProxyReady(65534, 100)).toBe(false);
+      expect((proxy as any).isReady).toBe(false);
+      expect(proxy.flushLogs()).toEqual(expect.arrayContaining([expect.stringContaining('unreachable')]));
+    });
+
+    it('resets isReady on detachCurrent', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-20260909-120000';
+      (proxy as any).ip = '127.0.0.1';
+      (proxy as any).isReady = true;
+
+      expect(proxy.detachCurrent()).toBe(true);
+      expect((proxy as any).isReady).toBe(false);
+      expect(proxy.getDispatcher()).toBeUndefined();
+    });
+
+    it('discards stale probe result when start() replaces proxy before probe settles', async () => {
+      const proxy = new Proxy('inreach');
+      (proxy as any).name = 'proxy-vm-1';
+      (proxy as any).ip = '10.0.0.1';
+
+      let finishProbe1!: () => void;
+      const probe1Promise = new Promise<void>((resolve) => {
+        finishProbe1 = resolve;
+      });
+
+      let connectCalls = 0;
+      vi.spyOn(net, 'connect').mockImplementation(() => {
+        connectCalls++;
+        const socket = new net.Socket();
+        if (connectCalls === 1) {
+          probe1Promise.then(() => socket.emit('connect'));
+        }
+        return socket;
+      });
+
+      // 1. Launch probe for proxy VM-1
+      const probe1 = (proxy as any).checkProxyReady();
+
+      // 2. Interleave: proxy is replaced (as start() does) while probe 1 is in-flight
+      (proxy as any).name = 'proxy-vm-2';
+      (proxy as any).ip = '10.0.0.2';
+      (proxy as any).isReady = false;
+      (proxy as any).generation++;
+
+      // 3. Probe 1 completes after replacement
+      finishProbe1();
+      const probe1Result = await probe1;
+
+      // 4. Stale probe result is discarded; VM-2 is NOT marked ready
+      expect(probe1Result).toBe(false);
+      expect((proxy as any).isReady).toBe(false);
+
+      // 5. Subsequent isReadyOrStart() does not skip validation of VM-2
+      const checkProxyReadySpy = vi.spyOn(proxy as any, 'checkProxyReady').mockResolvedValue(false);
+      const readyForVm2 = await proxy.isReadyOrStart();
+      expect(readyForVm2).toBe(false);
+      expect(checkProxyReadySpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/fetcher/src/app/trackers/proxy.ts
+++ b/apps/fetcher/src/app/trackers/proxy.ts
@@ -1,3 +1,6 @@
+import { once } from 'node:events';
+import net from 'node:net';
+
 import { InstancesClient, InstanceTemplatesClient, ZoneOperationsClient } from '@google-cloud/compute';
 import { format } from 'date-fns';
 import { ProxyAgent } from 'undici';
@@ -48,6 +51,12 @@ export class Proxy {
   /** Cached ProxyAgent dispatcher pointing to the active proxy instance. */
   private dispatcher: ProxyAgent | null = null;
 
+  /** Whether the proxy container is confirmed to be accepting connections on port 80. */
+  private isReady = false;
+
+  /** Monotonically increasing lifecycle generation to detect and discard stale probe results. */
+  private generation = 0;
+
   /** Buffered log messages for Redis/diagnostic inspection. */
   private logs: string[] = [];
 
@@ -80,6 +89,8 @@ export class Proxy {
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       this.name = format(new Date(), "'proxy-'yyyyMMdd-HHmmss");
       this.ip = null;
+      this.isReady = false;
+      this.generation++;
       this.closeDispatcher();
       const zone = this.getNextZone();
 
@@ -245,14 +256,20 @@ export class Proxy {
   }
 
   /**
-   * Checks whether the proxy is ready to handle requests.
+   * Checks whether the proxy is ready to handle requests without blocking.
    *
-   * If no proxy has been requested yet (`name == null`), triggers {@link start}
-   * asynchronously and returns `false`.
+   * 1. If no proxy has been requested yet (`name == null`), triggers {@link start}
+   *    asynchronously in the background and returns `false`.
+   * 2. If the VM is still being provisioned by GCE (`ip == null`), returns `false`.
+   * 3. If already verified ready, returns `true` immediately.
+   * 4. If the IP is known but not yet verified, performs a single non-blocking
+   *    TCP connection probe to port 80 (timeout: 1000ms).
+   *    - If port 80 connects: sets `isReady = true`, logs readiness, returns `true`.
+   *    - If refused or timed out: logs unreachable and returns `false`.
    *
-   * @returns `true` if the VM is running and its IP address is known; `false` otherwise.
+   * @returns `true` if the VM is running and its proxy container is accepting connections on port 80; `false` otherwise.
    */
-  public isReadyOrStart(): boolean {
+  public async isReadyOrStart(): Promise<boolean> {
     if (this.name == null) {
       // No proxy starting, start one.
       this.start();
@@ -262,7 +279,40 @@ export class Proxy {
       // Waiting for a proxy to be ready.
       return false;
     }
-    return true;
+    if (this.isReady) {
+      return true;
+    }
+
+    return await this.checkProxyReady();
+  }
+
+  /**
+   * Probes whether the proxy is accepting TCP connections and updates `isReady`.
+   *
+   * @param port - Port to connect to (default 80).
+   * @param timeoutMs - Connection timeout in milliseconds (default 1000).
+   * @returns `true` if connected successfully; `false` on error or timeout.
+   */
+  protected async checkProxyReady(port = 80, timeoutMs = 1000): Promise<boolean> {
+    if (!this.ip) {
+      return false;
+    }
+    const expectedGeneration = this.generation;
+    const socket = net.connect({ host: this.ip, port });
+    try {
+      await once(socket, 'connect', { signal: AbortSignal.timeout(timeoutMs) });
+      if (this.generation === expectedGeneration) {
+        this.isReady = true;
+      }
+    } catch {
+      if (this.generation === expectedGeneration) {
+        this.isReady = false;
+        this.log(`Proxy ${this.name} (${this.ip}) unreachable`);
+      }
+    } finally {
+      socket.destroy();
+    }
+    return this.generation === expectedGeneration && this.isReady;
   }
 
   /**
@@ -293,6 +343,8 @@ export class Proxy {
     const hasCurrent = this.name != null;
     this.name = null;
     this.ip = null;
+    this.isReady = false;
+    this.generation++;
     this.closeDispatcher();
     return hasCurrent;
   }


### PR DESCRIPTION
## Summary by Sourcery

Ensure tracker fetching waits for the proxy to accept connections before issuing requests.

New Features:
- Add asynchronous proxy readiness checks that verify the proxy accepts TCP connections before tracker requests are sent.

Bug Fixes:
- Prevent tracker fetches from being attempted while the proxy is unavailable, and report proxy-unreachable errors instead.
- Discard stale readiness results when the active proxy instance changes.

Enhancements:
- Track and reset proxy readiness across proxy lifecycle changes while caching successful readiness checks.

Tests:
- Add coverage for proxy startup, TCP readiness probing, readiness caching, lifecycle resets, and stale probe handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy readiness handling before fetch cycles begin.
  - Fetch operations now skip only when a required proxy is unreachable, while maintenance tasks continue normally.
  - Added TCP connectivity checks to reduce failed fetch attempts and improve reliability.
  - Proxy readiness is reset when a proxy starts or detaches, ensuring checks use the current connection state.
  - Prevented outdated connectivity results from affecting a newly replaced proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->