### PR TITLE
perf: release the socket on error

### DIFF
--- a/apps/fetcher/src/app/trackers/flymaster.ts
+++ b/apps/fetcher/src/app/trackers/flymaster.ts
@@ -65,6 +65,8 @@ export class FlymasterFetcher extends TrackerFetcher {
             updates.errors.push(`Error parsing the json for ${url}\n${e}`);
           }
         } else {
+          // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+          await response.body?.cancel();
           updates.errors.push(`HTTP Status = ${response.status} for ${url}`);
         }
       } catch (e) {

--- a/apps/fetcher/src/app/trackers/flyme.ts
+++ b/apps/fetcher/src/app/trackers/flyme.ts
@@ -41,6 +41,8 @@ export class FlymeFetcher extends TrackerFetcher {
           updates.errors.push(`Error parsing JSON ${response.body}\n${e}`);
         }
       } else {
+        // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+        await response.body?.cancel();
         updates.errors.push(`HTTP status ${response.status}`);
       }
     } catch (e) {

--- a/apps/fetcher/src/app/trackers/inreach.ts
+++ b/apps/fetcher/src/app/trackers/inreach.ts
@@ -96,6 +96,8 @@ export class InreachFetcher extends TrackerFetcher {
               updates.trackerErrors.set(id, `Error parsing the kml for ${id}\n${e}`);
             }
           } else {
+            // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+            await response.body?.cancel();
             updates.trackerErrors.set(id, `HTTP Status = ${response.status} for ${url}`);
             if (response.status == 429) {
               if (!isRateLimited && !useProxy) {

--- a/apps/fetcher/src/app/trackers/skylines.ts
+++ b/apps/fetcher/src/app/trackers/skylines.ts
@@ -69,6 +69,8 @@ export class SkylinesFetcher extends TrackerFetcher {
             updates.errors.push(`Error parsing the json for ${url}\n${e}`);
           }
         } else {
+          // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+          await response.body?.cancel();
           updates.errors.push(`HTTP Status = ${response.status} for ${url}`);
         }
       } catch (e) {

--- a/apps/fetcher/src/app/trackers/spot.ts
+++ b/apps/fetcher/src/app/trackers/spot.ts
@@ -51,6 +51,8 @@ export class SpotFetcher extends TrackerFetcher {
             updates.trackerErrors.set(id, `Error parsing the json for ${id}\n${e}`);
           }
         } else {
+          // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+          await response.body?.cancel();
           updates.trackerErrors.set(id, `HTTP Status = ${response.status} for ${url}`);
         }
       } catch (e) {

--- a/apps/fetcher/src/app/trackers/xcontest.ts
+++ b/apps/fetcher/src/app/trackers/xcontest.ts
@@ -61,6 +61,8 @@ export class XcontestFetcher extends TrackerFetcher {
           updates.errors.push(`Error parsing JSON ${response.body}\n${e}`);
         }
       } else {
+        // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+        await response.body?.cancel();
         updates.errors.push(`HTTP status ${response.status}`);
       }
     } catch (e) {
@@ -116,6 +118,8 @@ export class XcontestFetcher extends TrackerFetcher {
             updates.trackerErrors.set(deviceId, `Error parsing JSON ${response.body}\n${e}`);
           }
         } else {
+          // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+          await response.body?.cancel();
           updates.trackerErrors.set(deviceId, `HTTP status ${response.status}`);
         }
       } catch (e) {

--- a/apps/fetcher/src/app/ufos/aviant.ts
+++ b/apps/fetcher/src/app/ufos/aviant.ts
@@ -28,6 +28,8 @@ export class AviantFetcher extends UfoFleetFetcher {
           }
         }
       } else {
+        // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool.
+        await response.body?.cancel();
         updates.errors.push(`HTTP status ${response.status}`);
       }
     } catch (e) {

--- a/libs/common/src/lib/fetch-timeout.test.ts
+++ b/libs/common/src/lib/fetch-timeout.test.ts
@@ -48,6 +48,31 @@ describe('fetchResponse', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it('should cancel response body when retrying transient status to release socket to pool', async () => {
+    const res500 = new Response('error', { status: 500 });
+    const res200 = new Response('ok', { status: 200 });
+
+    let resolveCancel!: () => void;
+    const cancelPromise = new Promise<void>((resolve) => {
+      resolveCancel = resolve;
+    });
+    const cancelSpy = vi.spyOn(res500.body!, 'cancel').mockReturnValue(cancelPromise);
+    const retryFetchSpy = vi.fn().mockResolvedValueOnce(res200);
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(res500).mockImplementationOnce(retryFetchSpy);
+
+    const fetchPromise = fetchResponse('https://example.com/test', { retry: 3 });
+
+    // Flush one microtask tick so the first fetch resolves and cancel() is called, but cancelPromise is still pending.
+    await Promise.resolve();
+    expect(cancelSpy).toHaveBeenCalled();
+    expect(retryFetchSpy).not.toHaveBeenCalled();
+
+    resolveCancel();
+    const res = await fetchPromise;
+    expect(res.status).toBe(200);
+    expect(retryFetchSpy).toHaveBeenCalled();
+  });
+
   it('should throw when retries are exhausted on status 503', async () => {
     const res503 = new Response('unavailable', { status: 503 });
     globalThis.fetch = vi.fn().mockResolvedValue(res503);

--- a/libs/common/src/lib/fetch-timeout.ts
+++ b/libs/common/src/lib/fetch-timeout.ts
@@ -174,6 +174,8 @@ export async function fetchResponse(url: string, options?: FetchResponseOptions)
       }
 
       if (retryOnStatus.has(response.status)) {
+        // Cancel the unconsumed response body to immediately release the underlying socket back to the connection pool before retrying.
+        await response.body?.cancel();
         log && console.log(`retry on status ${response.status} ${(Date.now() / 1000 - start).toFixed(1)}s`);
         error = new Error(`Status = ${response.status}`);
         continue;


### PR DESCRIPTION
## Summary by Sourcery

Release unconsumed HTTP response bodies before reporting errors or retrying requests to improve connection reuse.

Bug Fixes:
- Release unconsumed HTTP response bodies on non-success responses to prevent sockets from being held unnecessarily.
- Release response bodies before retrying transient HTTP failures so retries do not wait on exhausted connection resources.

Tests:
- Add coverage verifying response cancellation completes before a transient-status retry begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network connection handling when tracker and service requests return errors.
  - Prevented discarded error responses from tying up connections, helping the fetcher recover more reliably and continue processing requests.
  - Improved retry behavior for temporary server errors, allowing subsequent attempts to proceed cleanly.
  - Applied more consistent response cleanup across supported tracking and service integrations.

- **Tests**
  - Added coverage to verify that temporary HTTP failures release resources before retrying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->