### PR TITLE
feat(windy-plugin) use color scales for temp and wind

### DIFF
--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -5,6 +5,7 @@ import * as atm from '../util/atmosphere.js';
 import type { Scale } from '../util/math.js';
 import * as math from '../util/math.js';
 import { Parcel } from './parcel.jsx';
+import { TemperatureGradient } from './temperature-gradient';
 
 export type SkewTProps = {
   width: number;
@@ -221,18 +222,9 @@ export function SkewT(props: SkewTProps) {
       <g className="line">
         {parcel && <Parcel {...{ parcel, width, height, pathGenerator, pressureToPxScale, formatAltitude }} />}
         <defs>
-          <linearGradient
-            id="tempGrad"
-            gradientUnits="userSpaceOnUse"
-            x1={tempToPxScale(gradientMinTemp)}
-            y1="0"
-            x2={tempToPxScale(gradientMaxTemp)}
-            y2="0"
-          >
-            {gradientTempStops.map(({ offset, color }) => (
-              <stop key={offset} offset={offset} stop-color={color} />
-            ))}
-          </linearGradient>
+          <TemperatureGradient
+            {...{ tempToPxScale, gradientMinTemp, gradientMaxTemp, height, skew, gradientTempStops }}
+          />
         </defs>
         <path className="temperature" stroke="url(#tempGrad)" d={pathGenerator(math.zip(temps, levels))} />
         <path className="dewpoint" d={pathGenerator(math.zip(dewPoints, levels))} />

--- a/libs/windy-sounding/src/components/skewt.tsx
+++ b/libs/windy-sounding/src/components/skewt.tsx
@@ -114,6 +114,18 @@ export function SkewT(props: SkewTProps) {
     surfaceElevation,
   ]);
 
+  const [{ gradientMinTemp, gradientMaxTemp, gradientTempStops }] = useState(() => {
+    const gradient = W.colors.temp.getColorGradient();
+    const gradientMinTemp = gradient[0][0];
+    const gradientMaxTemp = gradient[gradient.length - 1][0];
+    const gradientTempStops = gradient.map(([temp, color]) => ({
+      offset: math.round((temp - gradientMinTemp) / (gradientMaxTemp - gradientMinTemp), 2),
+      color: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+    }));
+
+    return { gradientMinTemp, gradientMaxTemp, gradientTempStops };
+  });
+
   const axisElement = useMemo(
     () => (
       <g className="axis">
@@ -208,11 +220,39 @@ export function SkewT(props: SkewTProps) {
     () => (
       <g className="line">
         {parcel && <Parcel {...{ parcel, width, height, pathGenerator, pressureToPxScale, formatAltitude }} />}
-        <path className="temperature" d={pathGenerator(math.zip(temps, levels))} />
+        <defs>
+          <linearGradient
+            id="tempGrad"
+            gradientUnits="userSpaceOnUse"
+            x1={tempToPxScale(gradientMinTemp)}
+            y1="0"
+            x2={tempToPxScale(gradientMaxTemp)}
+            y2="0"
+          >
+            {gradientTempStops.map(({ offset, color }) => (
+              <stop key={offset} offset={offset} stop-color={color} />
+            ))}
+          </linearGradient>
+        </defs>
+        <path className="temperature" stroke="url(#tempGrad)" d={pathGenerator(math.zip(temps, levels))} />
         <path className="dewpoint" d={pathGenerator(math.zip(dewPoints, levels))} />
       </g>
     ),
-    [parcel, width, height, pathGenerator, pressureToPxScale, formatAltitude, temps, dewPoints, levels],
+    [
+      parcel,
+      width,
+      height,
+      pathGenerator,
+      pressureToPxScale,
+      formatAltitude,
+      temps,
+      dewPoints,
+      levels,
+      tempToPxScale,
+      gradientMinTemp,
+      gradientMaxTemp,
+      gradientTempStops,
+    ],
   );
 
   let tempAtCursor = 0;

--- a/libs/windy-sounding/src/components/temperature-gradient.tsx
+++ b/libs/windy-sounding/src/components/temperature-gradient.tsx
@@ -1,0 +1,50 @@
+import type { Scale } from '../util/math.js';
+
+/**
+ * Defines a gradient vector parallel to the Skew-T temperature axis, so a
+ * temperature keeps the same color at every pressure level. Its vector is
+ * `(gradientLength, skew * gradientLength)`; `gradientLength` is the
+ * horizontal temperature range projected onto that vector.
+ *
+ * @param tempToPxScale Maps a temperature to its horizontal chart position.
+ * @param gradientMinTemp Lowest temperature represented by the color scale.
+ * @param gradientMaxTemp Highest temperature represented by the color scale.
+ * @param height Chart height in pixels.
+ * @param skew Horizontal displacement per vertical pixel in the Skew-T projection.
+ * @param gradientTempStops Color stops normalized across the temperature range.
+ */
+export function TemperatureGradient({
+  tempToPxScale,
+  gradientMinTemp,
+  gradientMaxTemp,
+  height,
+  skew,
+  gradientTempStops,
+}: {
+  tempToPxScale: Scale;
+  gradientMinTemp: number;
+  gradientMaxTemp: number;
+  height: number;
+  skew: number;
+  gradientTempStops: { offset: number; color: string }[];
+}) {
+  const xMinTemp = tempToPxScale(gradientMinTemp);
+  const x1 = xMinTemp + skew * height;
+  // Project the horizontal temperature range onto the gradient vector.
+  const gradientLength = (tempToPxScale(gradientMaxTemp) - xMinTemp) / (1 + skew ** 2);
+
+  return (
+    <linearGradient
+      id="tempGrad"
+      gradientUnits="userSpaceOnUse"
+      {...{ x1 }}
+      y1="0"
+      x2={x1 + gradientLength}
+      y2={skew * gradientLength}
+    >
+      {gradientTempStops.map(({ offset, color }) => (
+        <stop key={offset} offset={offset} stop-color={color} />
+      ))}
+    </linearGradient>
+  );
+}

--- a/libs/windy-sounding/src/components/wind-profile.tsx
+++ b/libs/windy-sounding/src/components/wind-profile.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 
 import { getPressureToGhScale } from '../util/atmosphere';
 import * as math from '../util/math';
@@ -72,12 +72,38 @@ export function WindProfile(props: WindProfileProps) {
     };
   }, [levels, minPressure, speeds, ghs, seaLevelPressure, maxPressure, height, isFixedRange, width, surfaceElevation]);
 
+  const [{ gradientMinSpeed, gradientMaxSpeed, gradientSpeedStops }] = useState(() => {
+    const gradient = W.colors.wind.getColorGradient();
+    const gradientMinSpeed = gradient[0][0];
+    const gradientMaxSpeed = gradient[gradient.length - 1][0];
+    const gradientSpeedStops = gradient.map(([speed, color]) => ({
+      offset: math.round((speed - gradientMinSpeed) / (gradientMaxSpeed - gradientMinSpeed), 2),
+      color: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+    }));
+
+    return { gradientMinSpeed, gradientMaxSpeed, gradientSpeedStops };
+  });
+
   const chartElements = useMemo(
     () => (
       <>
         <rect width={width} height={height} className="background" />
         <WindAxis {...{ speedToPxScale, width, height, maxSpeed, unit, format, isZoomedIn: isFixedRange }} />
-        <path className="speed line" d={pathGenerator(math.zip(speeds, levels))} />
+        <defs>
+          <linearGradient
+            id="windGrad"
+            gradientUnits="userSpaceOnUse"
+            x1={speedToPxScale(gradientMinSpeed)}
+            y1="0"
+            x2={speedToPxScale(gradientMaxSpeed)}
+            y2="0"
+          >
+            {gradientSpeedStops.map(({ offset, color }) => (
+              <stop key={offset} offset={offset} stop-color={color} />
+            ))}
+          </linearGradient>
+        </defs>
+        <path className="speed line" stroke="url(#windGrad)" d={pathGenerator(math.zip(speeds, levels))} />
         <g transform={`translate(${width / 2}, 0)`}>
           {levels.map((level: number, i: number) => {
             if (level > surfacePressure) {

--- a/libs/windy-sounding/src/env.d.ts
+++ b/libs/windy-sounding/src/env.d.ts
@@ -24,5 +24,6 @@ declare const W: {
   overlays: typeof import('@windy/client/overlays').default;
   reverseName: typeof import('@windy/client/reverseName');
   geolocation: typeof import('@windy/client/geolocation');
+  colors: typeof import('@windy/client/colors').default;
 };
 /* eslint-enable */

--- a/libs/windy-sounding/src/style/skewt.less
+++ b/libs/windy-sounding/src/style/skewt.less
@@ -227,10 +227,6 @@
 
       // Atmospheric sounding profile curves (Temperature & Dewpoint)
       .line {
-        .temperature {
-          stroke: red;
-        }
-
         .dewpoint {
           stroke: steelblue;
         }
@@ -325,13 +321,6 @@
       // Cursor wind speed readout
       text.speed {
         fill: purple;
-      }
-
-      // Wind speed curve
-      .line {
-        &.speed {
-          stroke: purple;
-        }
       }
 
       // Wind speed grid axis

--- a/libs/windy-sounding/tsconfig.json
+++ b/libs/windy-sounding/tsconfig.json
@@ -11,7 +11,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"
   },


### PR DESCRIPTION
## Summary by Sourcery

Use Windy color scales to color temperature and wind curves throughout sounding visualizations.

New Features:
- Apply Windy color scales to temperature and wind-profile curves in the sounding charts.

Enhancements:
- Render temperature colors consistently along the Skew-T projection using a dedicated gradient component.
- Expose the Windy colors API to the sounding package and update JSX configuration for Preact compatibility.

Chores:
- Remove fixed temperature and wind curve colors in favor of the dynamic gradients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Added temperature-based color gradients to Skew-T temperature traces.
  - Added wind-speed gradients to wind profile chart lines, improving visual readability across varying speeds.

- **Style**
  - Updated chart styling so line colors are driven by dynamic gradients while preserving existing readout text styling.
  - Improved gradient rendering for clearer visualization of temperature and wind-speed variation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->