### PR TITLE
fix: a couple of minor fixes

### DIFF
--- a/secrets.d.ts
+++ b/secrets.d.ts
@@ -12,7 +12,7 @@ declare const SECRETS: {
   AVIANT_URL: string;
   APRS_USER: string;
   APRS_PASSWORD: string;
-  ZOLEO_API_KEY?: string;
+  ZOLEO_API_KEY: string;
   ZOLEO_PUSH_USER: string;
   ZOLEO_PUSH_PWD: string;
   XCONTEST_JWT: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['**/*/vite.config.ts', '**/*/vitest.config.ts'],
+    projects: ['**/*/vite.config.ts', '**/*/vitest.config.ts', '!**/dist/workspace_modules/**'],
   },
 });


### PR DESCRIPTION
## Summary by Sourcery

Tighten ZOLEO secret typing and exclude generated workspace modules from Vitest project discovery.

Bug Fixes:
- Require the ZOLEO API key in the secrets type definition.
- Prevent Vitest from discovering generated workspace modules under dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * API key configuration is now treated as required, helping ensure complete setup before use.
  * Workspace module directories are excluded from automated test project discovery, improving test configuration accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->