### PR TITLE
fix(zoleo): use imei as the account

### DIFF
--- a/apps/fetcher/src/app/state/sync.test.ts
+++ b/apps/fetcher/src/app/state/sync.test.ts
@@ -15,7 +15,7 @@ const FLYME = '001';
 const SKYLINES = '002';
 const FLYMASTER = '003';
 const OGN = `123456`;
-const ZOLEO = `12345678-1234-1234-1234-123456789012`;
+const ZOLEO = `012345678912345`;
 const XCONTEST = `a123456789012345678901234567`;
 const MESHBIR = `12345678-1234-1234-1234-123456789012`;
 
@@ -312,7 +312,7 @@ function createTrackerEntity(
       break;
     case 'zoleo':
       entity.account = account;
-      entity.imei = '012345678912345';
+      entity.device_id = '12345678-1234-1234-1234-123456789012';
       break;
   }
   return entity;

--- a/apps/fetcher/src/app/trackers/zoleo.test.ts
+++ b/apps/fetcher/src/app/trackers/zoleo.test.ts
@@ -6,86 +6,80 @@ import { handleLocationlessMessage, parse } from './zoleo';
 describe('parse', () => {
   it('should parse messages', () => {
     vi.useFakeTimers({ now: 1687736000000 });
-    const id = '12345678-1234-1234-1234-123456789012';
+    const device_id = '12345678-1234-1234-1234-123456789012';
+    const imei = '012345678912345';
     const zoleoMsgs: ZoleoMessage[] = [
-      { type: 'imei', id, imei: '012345678912345' },
+      { type: 'imei', device_id, imei },
       {
         type: 'location',
-        id: '12345678-1234-1234-1234-123456789012',
         lat: 37.38525,
         lon: -122.02778,
         altitudeM: 321,
         batteryPercent: 25,
         timeMs: 1687735167893,
-        imei: '012345678912345',
+        imei,
         message: 'Check-In',
       },
       {
         type: 'message',
-        id,
         lat: 37.3855,
         lon: -122.0275,
         altitudeM: 320,
         timeMs: 1687735169000,
-        imei: '012345678912345',
+        imei,
         batteryPercent: 100,
         message: 'Email with location',
       },
       {
         type: 'message',
-        id,
         timeMs: 1687736000000,
-        imei: '012345678912345',
+        imei,
         batteryPercent: 100,
         message: 'Email without location',
       },
       {
         type: 'location',
-        id: '12345678-1234-1234-1234-123456789012',
         lat: 37.38525,
         lon: -122.02778,
         altitudeM: 322,
         batteryPercent: 20,
         timeMs: 1687735170324,
-        imei: '012345678912345',
+        imei,
       },
       {
         type: 'location',
-        id: '12345678-1234-1234-1234-123456789012',
         lat: 37.38532,
         lon: -122.02776,
         altitudeM: 323,
         batteryPercent: 15,
         timeMs: 1687735352016,
-        imei: '012345678912345',
+        imei,
       },
       {
         type: 'location',
-        id: '12345678-1234-1234-1234-123456789012',
         lat: 37.38718,
         lon: -122.02649,
         altitudeM: 324,
         batteryPercent: 10,
         timeMs: 1687735712035,
-        imei: '012345678912345',
+        imei,
       },
       {
         type: 'location',
-        id: '12345678-1234-1234-1234-123456789012',
         lat: 37.38475,
         lon: -122.02825,
         altitudeM: 325,
         batteryPercent: 5,
         timeMs: 1687735999608,
-        imei: '012345678912345',
+        imei,
       },
     ];
 
-    const pointsById = parse(zoleoMsgs);
+    const pointsByImei = parse(zoleoMsgs);
     handleLocationlessMessage(
       zoleoMsgs,
-      pointsById,
-      new Map([[id, 10]]),
+      pointsByImei,
+      new Map([[imei, 10]]),
       {
         '10': protos.Pilot.create({
           track: protos.LiveTrack.create({
@@ -99,9 +93,9 @@ describe('parse', () => {
       15,
     );
 
-    expect(pointsById).toMatchInlineSnapshot(`
+    expect(pointsByImei).toMatchInlineSnapshot(`
       Map {
-        "12345678-1234-1234-1234-123456789012" => [
+        "012345678912345" => [
           {
             "alt": 321,
             "lat": 37.38525,
@@ -164,21 +158,20 @@ describe('parse', () => {
 
   it('should attach a location-less message to a recent known position', () => {
     vi.useFakeTimers({ now: 234500 });
-    const id = '12345678-1234-1234-1234-123456789012';
+    const imei = '012345678912345';
 
     const message: ZoleoMessage = {
       type: 'message',
-      id,
       timeMs: 234440,
-      imei: '012345678912345',
+      imei,
       batteryPercent: 100,
       message: 'Email message',
     };
-    const pointsById = parse([message]);
+    const pointsByImei = parse([message]);
     handleLocationlessMessage(
       [message],
-      pointsById,
-      new Map([[id, 10]]),
+      pointsByImei,
+      new Map([[imei, 10]]),
       {
         '10': protos.Pilot.create({
           track: protos.LiveTrack.create({
@@ -192,10 +185,10 @@ describe('parse', () => {
       1,
     );
 
-    expect(pointsById).toEqual(
+    expect(pointsByImei).toEqual(
       new Map([
         [
-          id,
+          imei,
           [
             {
               lat: 21,
@@ -212,17 +205,16 @@ describe('parse', () => {
   });
 
   it('should add a message with a location as a new point', () => {
-    const id = '12345678-1234-1234-1234-123456789012';
+    const imei = '012345678912345';
 
     expect(
       parse([
         {
           type: 'message',
-          id,
           lat: 45.182,
           lon: 5.73797,
           timeMs: 234500,
-          imei: '012345678912345',
+          imei,
           batteryPercent: 100,
           message: 'Email message',
         },
@@ -230,7 +222,7 @@ describe('parse', () => {
     ).toEqual(
       new Map([
         [
-          id,
+          imei,
           [
             {
               lat: 45.182,

--- a/apps/fetcher/src/app/trackers/zoleo.ts
+++ b/apps/fetcher/src/app/trackers/zoleo.ts
@@ -39,14 +39,14 @@ export class ZoleoFetcher extends TrackerFetcher {
     }
 
     // Add new devices.
-    const addedDevices = await confirmZoleoConsent(this.datastore, messages);
+    const addedDevices = await handleZoleoConsent(this.datastore, messages);
     if (addedDevices > 0) {
       // Sync added devices
       this.pipeline.incr(Keys.fetcherCmdSyncIncCount);
     }
 
-    // Maps device ID to datastore ids.
-    const idToDsId = new Map<string, number>();
+    // Maps IMEI to datastore ids.
+    const imeiToDsId = new Map<string, number>();
     for (const dsId of devices) {
       const tracker = this.getTracker(dsId);
       if (tracker == null) {
@@ -57,13 +57,13 @@ export class ZoleoFetcher extends TrackerFetcher {
         updates.trackerErrors.set(dsId, `Invalid account ${tracker.account}`);
         continue;
       }
-      idToDsId.set(tracker.account, dsId);
+      imeiToDsId.set(tracker.account, dsId);
     }
 
-    const pointsById = parse(messages);
-    handleLocationlessMessage(messages, pointsById, idToDsId, this.state.pilots, MESSAGE_AFFINITY_MIN);
-    for (const [id, points] of pointsById.entries()) {
-      const dsId = idToDsId.get(id);
+    const pointsByImei = parse(messages);
+    handleLocationlessMessage(messages, pointsByImei, imeiToDsId, this.state.pilots, MESSAGE_AFFINITY_MIN);
+    for (const [imei, points] of pointsByImei.entries()) {
+      const dsId = imeiToDsId.get(imei);
       if (dsId != null) {
         updates.trackerDeltas.set(dsId, makeLiveTrack(points));
       }
@@ -77,21 +77,21 @@ export class ZoleoFetcher extends TrackerFetcher {
 }
 
 /**
- * Converts queued Zoleo messages into live-track points grouped by device ID.
+ * Converts queued Zoleo messages into live-track points grouped by IMEI.
  *
  * Only location updates and messages that include coordinates become points.
  * Location-less messages are handled separately after all locations are parsed.
  *
  * @param messages Queued Zoleo messages to convert.
- * @returns Live-track points grouped by Zoleo device ID.
+ * @returns Live-track points grouped by Zoleo IMEI.
  */
 export function parse(messages: ZoleoMessage[]): Map<string, LivePoint[]> {
-  const pointsById = new Map<string, LivePoint[]>();
+  const pointsByImei = new Map<string, LivePoint[]>();
 
   for (const msg of messages) {
     if (msg.type === 'location') {
-      const points = pointsById.get(msg.id) ?? [];
-      pointsById.set(msg.id, points);
+      const points = pointsByImei.get(msg.imei) ?? [];
+      pointsByImei.set(msg.imei, points);
       const point: LivePoint = {
         lat: msg.lat,
         lon: msg.lon,
@@ -110,8 +110,8 @@ export function parse(messages: ZoleoMessage[]): Map<string, LivePoint[]> {
       }
       points.push(point);
     } else if (msg.type === 'message' && msg.lat != null && msg.lon != null) {
-      const points = pointsById.get(msg.id) ?? [];
-      pointsById.set(msg.id, points);
+      const points = pointsByImei.get(msg.imei) ?? [];
+      pointsByImei.set(msg.imei, points);
       const point: LivePoint = {
         lat: msg.lat,
         lon: msg.lon,
@@ -127,7 +127,7 @@ export function parse(messages: ZoleoMessage[]): Map<string, LivePoint[]> {
     }
   }
 
-  return pointsById;
+  return pointsByImei;
 }
 
 /**
@@ -137,15 +137,15 @@ export function parse(messages: ZoleoMessage[]): Map<string, LivePoint[]> {
  * the tracker's latest fix is older than the affinity window.
  *
  * @param messages Queued Zoleo messages to reconcile.
- * @param pointsById Points collected for each Zoleo device in this cycle.
- * @param idToDsId Mapping from Zoleo device IDs to datastore IDs.
+ * @param pointsByImei Points collected for each Zoleo device in this cycle.
+ * @param imeiToDsId Mapping from Zoleo IMEIs to datastore IDs.
  * @param pilots Current pilot tracks used to resolve location-less messages.
  * @param messageAffinityMin Maximum age, in minutes, of a fix used for a message.
  */
 export function handleLocationlessMessage(
   messages: ZoleoMessage[],
-  pointsById: Map<string, LivePoint[]>,
-  idToDsId: Map<string, number>,
+  pointsByImei: Map<string, LivePoint[]>,
+  imeiToDsId: Map<string, number>,
   pilots: Record<string, protos.Pilot>,
   messageAffinityMin: number,
 ): void {
@@ -154,7 +154,7 @@ export function handleLocationlessMessage(
       continue;
     }
 
-    const dsId = idToDsId.get(msg.id);
+    const dsId = imeiToDsId.get(msg.imei);
     if (dsId == null) {
       continue;
     }
@@ -168,8 +168,8 @@ export function handleLocationlessMessage(
       continue;
     }
 
-    const points = pointsById.get(msg.id) ?? [];
-    pointsById.set(msg.id, points);
+    const points = pointsByImei.get(msg.imei) ?? [];
+    pointsByImei.set(msg.imei, points);
     points.push({
       lat: track.lat.at(-1),
       lon: track.lon.at(-1),
@@ -182,9 +182,9 @@ export function handleLocationlessMessage(
 }
 
 /**
- * Populates the IMEI when a consent confirmation message is received.
+ * Populates the account with the IMEI when a consent confirmation message is received.
  */
-async function confirmZoleoConsent(datastore: Datastore, messages: ZoleoMessage[]): Promise<number> {
+async function handleZoleoConsent(datastore: Datastore, messages: ZoleoMessage[]): Promise<number> {
   // add new devices.
   let addedDevices = 0;
   for (const msg of messages) {
@@ -192,15 +192,15 @@ async function confirmZoleoConsent(datastore: Datastore, messages: ZoleoMessage[
       continue;
     }
     try {
-      const query = datastore.createQuery(LIVE_TRACK_TABLE).filter('zoleo.account', msg.id).limit(1);
+      const query = datastore.createQuery(LIVE_TRACK_TABLE).filter('zoleo.device_id', msg.device_id).limit(1);
       const [trackers] = await datastore.runQuery(query);
       if (trackers.length == 0) {
-        console.error(`Can not find zoleo id = ${msg.id}`);
+        console.error(`Can not find zoleo device_id = ${msg.device_id}`);
         continue;
       }
       const tracker = trackers[0];
       tracker.updated = new Date();
-      tracker.zoleo.imei = msg.imei;
+      tracker.zoleo.account = msg.imei;
 
       await datastore.save({
         key: tracker[Datastore.KEY],

--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -239,13 +239,13 @@ export class SettingsPage extends LitElement {
                       <ion-text class="ion-padding-horizontal ion-padding-top block">
                         Messages sent to <strong>zoleo@flyxc.app</strong> will be displayed flyXC.
                         ${when(
-                          this.binder.model.zoleo.account.valueOf().length > 0 &&
-                            this.binder.model.zoleo.imei.valueOf().length == 0,
+                          this.binder.model.zoleo.device_id.valueOf().length > 0 &&
+                            this.binder.model.zoleo.account.valueOf().length == 0,
                           () => html`<p>The consent must be confirmed via the email from zoleo.</p>`,
                         )}
                       </ion-text>
                       ${when(
-                        this.binder.model.zoleo.account.valueOf().length == 0,
+                        this.binder.model.zoleo.device_id.valueOf().length == 0,
                         () => html`<ion-item lines="full">
                           <ion-button size="default" @click=${async () => await this.openZoleoWebWidget()}
                             ><i class="las la-link la-lg"></i> Link a device</ion-button
@@ -310,9 +310,14 @@ export class SettingsPage extends LitElement {
    * POST a request to the server to unlink the Zoleo device.
    */
   private async unlinkZoleo() {
-    const binderNode = this.binder.for(this.binder.model.zoleo.account);
-    binderNode.value = '';
-    binderNode.visited = true;
+    // Clear the form model so the UI immediately shows "Link a device" and any subsequent
+    // form save preserves the unlinked state.
+    const deviceIdNode = this.binder.for(this.binder.model.zoleo.device_id);
+    deviceIdNode.value = '';
+    deviceIdNode.visited = true;
+    const accountNode = this.binder.for(this.binder.model.zoleo.account);
+    accountNode.value = '';
+    accountNode.visited = true;
     await fetchResponse(`${import.meta.env.VITE_API_SERVER}/api/zoleo/unlink`, {
       method: 'POST',
       credentials: 'include',
@@ -384,7 +389,8 @@ export class SettingsPage extends LitElement {
     const { partnerDeviceID } = event.data;
     if (partnerDeviceID) {
       const zoleoModel = this.binder.model.zoleo;
-      const binderNode = this.binder.for(zoleoModel.account);
+      const deviceIdNode = this.binder.for(zoleoModel.device_id);
+      const accountNode = this.binder.for(zoleoModel.account);
       const payload = {
         name: this.binder.model.name.valueOf(),
         deviceId: partnerDeviceID,
@@ -407,8 +413,10 @@ export class SettingsPage extends LitElement {
       }
 
       if (linked) {
-        binderNode.value = partnerDeviceID;
-        binderNode.visited = true;
+        deviceIdNode.value = partnerDeviceID;
+        deviceIdNode.visited = true;
+        accountNode.value = '';
+        accountNode.visited = true;
 
         const alert = await alertController.create({
           header: 'zoleo',
@@ -422,7 +430,10 @@ export class SettingsPage extends LitElement {
         });
         await alert.present();
       } else {
-        binderNode.value = '';
+        deviceIdNode.value = '';
+        deviceIdNode.visited = true;
+        accountNode.value = '';
+        accountNode.visited = true;
         const alert = await alertController.create({
           header: 'zoleo',
           message: 'Failed to link your Zoleo device. Please try again.',

--- a/apps/fxc-server/src/app/routes/zoleo.ts
+++ b/apps/fxc-server/src/app/routes/zoleo.ts
@@ -2,7 +2,6 @@ import { fetchResponse, Keys, type LiveTrackEntity } from '@flyxc/common';
 import type { RedisClient } from '@flyxc/common-node';
 import {
   getDatastore,
-  LIVE_TRACK_TABLE,
   parseMessage,
   pushListCap,
   retrieveLiveTrackByGoogleId,

--- a/apps/fxc-server/src/app/routes/zoleo.ts
+++ b/apps/fxc-server/src/app/routes/zoleo.ts
@@ -27,7 +27,7 @@ export function getZoleoRouter(redis: RedisClient): Router {
   const router = Router();
 
   /**
-   * Saves the Zoleo device ID to the user's entity in the datastore (in the account field).
+   * Saves the Zoleo device ID to the user's entity in the datastore (in the device_id field).
    *
    * This is called by the frontend when the user consent to sharing info.
    *
@@ -35,7 +35,7 @@ export function getZoleoRouter(redis: RedisClient): Router {
    * - This is different from the Zoleo link API which is not used.
    * - The devices becomes linked via a push message when users consents to sharing their info
    *   via the email link or via their zoleo account at myzoleo.com. The IMEI is populated at
-   *   that point.
+   *   that point (in the account field).
    */
   router.post('/link', async (req: Request, res: Response) => {
     try {
@@ -55,8 +55,8 @@ export function getZoleoRouter(redis: RedisClient): Router {
       }
       entity.name = name;
       entity.updated = new Date();
-      const imei = entity.zoleo?.account === deviceId ? entity.zoleo?.imei ?? '' : '';
-      entity.zoleo = { account: deviceId, enabled, imei };
+      const account = entity.zoleo?.device_id === deviceId ? entity.zoleo?.account ?? '' : '';
+      entity.zoleo = { account, device_id: deviceId, enabled };
 
       await datastore.save({
         key: entity[Datastore.KEY],
@@ -96,14 +96,14 @@ export function getZoleoRouter(redis: RedisClient): Router {
       const datastore = getDatastore();
       const { token } = userInfo;
       const entity = await retrieveLiveTrackByGoogleId(datastore, token);
-      if (!entity?.zoleo?.account) {
+      if (!entity?.zoleo?.device_id) {
         return res.sendStatus(204);
       }
 
       // Update the entity first so that users do not have to save the form even if the zoleo API call fails below.
-      deviceId = entity.zoleo.account;
+      deviceId = entity.zoleo.device_id;
       entity.updated = new Date();
-      entity.zoleo = { account: '', imei: '', enabled: false };
+      entity.zoleo = { account: '', device_id: '', enabled: false };
       await datastore.save({
         key: entity[Datastore.KEY],
         data: entity,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import eslintPluginImport from 'eslint-plugin-import';
 import eslintPluginLit from 'eslint-plugin-lit';
 import eslintPluginRequireNodeImportPrefix from 'eslint-plugin-require-node-import-prefix';
 import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslintPluginUnusedImports from 'eslint-plugin-unused-imports';
 import eslintPluginWc from 'eslint-plugin-wc';
 
 export default [
@@ -12,6 +13,7 @@ export default [
       '@nx': nxEslintPlugin,
       'require-node-import-prefix': eslintPluginRequireNodeImportPrefix,
       'simple-import-sort': eslintPluginSimpleImportSort,
+      'unused-imports': eslintPluginUnusedImports,
       import: eslintPluginImport,
     },
   },
@@ -38,6 +40,7 @@ export default [
       'import/first': 'error',
       'import/newline-after-import': 'error',
       'import/no-duplicates': 'error',
+      'unused-imports/no-unused-imports': 'error',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',

--- a/libs/common-node/src/lib/live-track-entity.ts
+++ b/libs/common-node/src/lib/live-track-entity.ts
@@ -44,10 +44,10 @@ export function updateLiveTrackEntityFromModel(
 
   for (const tracker of trackerNames) {
     const model = account[tracker];
-    // Preserve the current zoleo IMEI.
-    let imei: string | undefined;
+    // Preserve the current zoleo device ID.
+    let deviceId: string | undefined;
     if (tracker == 'zoleo') {
-      imei = liveTrack[tracker]?.imei ?? '';
+      deviceId = model.device_id ?? liveTrack[tracker]?.device_id ?? '';
     }
     liveTrack[tracker] = {
       enabled: model.enabled,
@@ -56,8 +56,8 @@ export function updateLiveTrackEntityFromModel(
     if (model.account_resolved != null) {
       liveTrack[tracker].account_resolved = model.account_resolved;
     }
-    if (imei != null) {
-      liveTrack[tracker].imei = imei ?? '';
+    if (deviceId != null) {
+      liveTrack[tracker].device_id = deviceId;
     }
   }
 

--- a/libs/common-node/src/lib/zoleo.test.ts
+++ b/libs/common-node/src/lib/zoleo.test.ts
@@ -9,7 +9,7 @@ describe('parseMessage', () => {
 
   it('parses an IMEI consent message', () => {
     expect(parseMessage({ IMEI: '123456789012345', partnerDeviceID: device.DeviceId })).toEqual({
-      id: device.DeviceId,
+      device_id: device.DeviceId,
       imei: '123456789012345',
       type: 'imei',
     });
@@ -26,7 +26,6 @@ describe('parseMessage', () => {
     ).toEqual({
       altitudeM: 0,
       batteryPercent: 100,
-      id: device.DeviceId,
       imei: device.DeviceIMEI,
       lat: 12.34568,
       lon: -23.45679,
@@ -60,7 +59,6 @@ describe('parseMessage', () => {
         Properties: properties,
       }),
     ).toMatchObject({
-      id: device.DeviceId,
       lat: 37.38762,
       lon: -122.02716,
       timeMs: 1687633329628,
@@ -93,7 +91,6 @@ describe('parseMessage', () => {
       }),
     ).toEqual({
       batteryPercent: 100,
-      id: device.DeviceId,
       imei: device.DeviceIMEI,
       message: 'Test message',
       timeMs: 1789104750671,
@@ -113,7 +110,6 @@ describe('parseMessage', () => {
     ).toEqual({
       altitudeM: 0,
       batteryPercent: 100,
-      id: device.DeviceId,
       imei: device.DeviceIMEI,
       lat: 43.62469,
       lon: -79.50503,
@@ -156,7 +152,7 @@ describe('parseMessage', () => {
     expect(
       parseMessage({
         MessageType: 'CheckIn',
-        DeviceIMEI: device.DeviceIMEI,
+        DeviceId: device.DeviceId,
         Location: { Latitude: 12.3456789, Longitude: -23.456789 },
         Properties: properties,
       }),

--- a/libs/common-node/src/lib/zoleo.ts
+++ b/libs/common-node/src/lib/zoleo.ts
@@ -10,7 +10,6 @@ export const ZOLEO_MAX_MESSAGE_SIZE = 200;
 export const ZOLEO_MAX_MSG = Math.floor((1_024 * 1024) / ZOLEO_MAX_MSG_SIZE);
 
 type ZoleoCommon = {
-  id: string;
   timeMs: number;
   imei: string;
   batteryPercent: number;
@@ -42,7 +41,7 @@ export type ZoleoMessage =
   /** Message sent when user consents to data sharing (via email link or myzoleo.com) */
   | {
       type: 'imei';
-      id: string;
+      device_id: string;
       imei: string;
     };
 
@@ -54,7 +53,7 @@ const zoleoImeiMessageSchema = z
   .loose()
   .transform((message) => ({
     type: 'imei' as const,
-    id: message.partnerDeviceID,
+    device_id: message.partnerDeviceID,
     imei: message.IMEI,
   }));
 
@@ -81,7 +80,6 @@ const zoleoEmailMessageSchema = z
   .object({
     MessageType: z.literal('EmailMessage'),
     DeviceIMEI: z.string().min(1),
-    DeviceId: z.string().min(1),
     Message: z.string().transform((message) => message.slice(0, ZOLEO_MAX_MESSAGE_SIZE)),
     Location: z
       .object({
@@ -98,7 +96,6 @@ const zoleoLocationMessageSchema = z
   .object({
     MessageType: z.string(),
     DeviceIMEI: z.string().min(1),
-    DeviceId: z.string().min(1),
     Location: zoleoLocationSchema,
     Properties: zoleoPropertiesSchema,
   })
@@ -118,10 +115,9 @@ export function parseMessage(message: unknown): ZoleoMessage | null {
 
   const emailParse = zoleoEmailMessageSchema.safeParse(message);
   if (emailParse.success) {
-    const { DeviceId, DeviceIMEI, Location, Message, Properties } = emailParse.data;
+    const { DeviceIMEI, Location, Message, Properties } = emailParse.data;
     const parsedMessage: ZoleoMessage = {
       type: 'message',
-      id: DeviceId,
       imei: DeviceIMEI,
       timeMs: Properties.EpochMiliseconds,
       batteryPercent: Properties.Battery,
@@ -140,10 +136,9 @@ export function parseMessage(message: unknown): ZoleoMessage | null {
     return null;
   }
 
-  const { MessageType, DeviceIMEI, DeviceId, Location, Properties } = payload.data;
+  const { MessageType, DeviceIMEI, Location, Properties } = payload.data;
   const zoleoMessage: ZoleoMessage = {
     type: 'location',
-    id: DeviceId,
     lat: Location.Latitude,
     lon: Location.Longitude,
     batteryPercent: Properties.Battery,

--- a/libs/common/src/lib/live-track-entity.ts
+++ b/libs/common/src/lib/live-track-entity.ts
@@ -6,9 +6,8 @@ export interface TrackerEntity {
   account: string;
   // Resolved account (i.e. the id retrieved from the account for flyme).
   account_resolved?: string;
-  // IMEI used by zoleo.
-  // For zoleo devices, the id is in account and the IMEI is populated after users consent to data sharing.
-  imei?: string;
+  // Device ID used by zoleo.
+  device_id?: string;
 }
 
 // A tracker user in the DataStore.

--- a/libs/common/src/lib/models.test.ts
+++ b/libs/common/src/lib/models.test.ts
@@ -164,19 +164,15 @@ describe('Validate OGN accounts', () => {
 
 describe('Validate zoleo accounts', () => {
   test('Valid ids', () => {
-    expect(validateZoleoAccount('12345678-1234-1234-1234-123456789012')).toBe('12345678-1234-1234-1234-123456789012');
-    expect(validateZoleoAccount('  12345678-1234-1234-1234-123456789012  ')).toBe(
-      '12345678-1234-1234-1234-123456789012',
-    );
-    expect(validateZoleoAccount('c5acc06a-c6f0-40c2-8987-e1a5ac53f6d9')).toBe('c5acc06a-c6f0-40c2-8987-e1a5ac53f6d9');
     expect(validateZoleoAccount('012345678912345')).toBe('012345678912345');
     expect(validateZoleoAccount('  012345678912345  ')).toBe('012345678912345');
-    expect(validateZoleoAccount('device-123')).toBe('device-123');
   });
 
   test('Invalid ids', () => {
     expect(validateZoleoAccount('')).toEqual(false);
-    expect(validateZoleoAccount('   ')).toEqual(false);
+    expect(validateZoleoAccount('01234567891234')).toEqual(false);
+    expect(validateZoleoAccount('0123456789123456')).toEqual(false);
+    expect(validateZoleoAccount('random')).toEqual(false);
   });
 });
 

--- a/libs/common/src/lib/models.ts
+++ b/libs/common/src/lib/models.ts
@@ -55,9 +55,9 @@ export class AccountFormModel extends ObjectModel<AccountModel> {
       if (trackerEntity.account_resolved != null) {
         trackerModels[prop].account_resolved = trackerEntity.account_resolved;
       }
-      // Copy the optional imei property (zoleo).
-      if (trackerEntity.imei != null) {
-        trackerModels[prop].imei = trackerEntity.imei;
+      // Copy the optional device_id property (zoleo).
+      if (trackerEntity.device_id != null) {
+        trackerModels[prop].device_id = trackerEntity.device_id;
       }
     }
 
@@ -100,8 +100,8 @@ export interface TrackerModel {
   enabled: boolean;
   // Account resolved on entity persisted (flyme).
   account_resolved?: string;
-  // IMEI used by zoleo (populated after users consent to data sharing).
-  imei?: string;
+  // Device ID used by zoleo.
+  device_id?: string;
 }
 
 // Form model for a client side tracker.
@@ -116,7 +116,7 @@ export class TrackerFormModel extends ObjectModel<TrackerModel> {
   readonly enabled: BooleanModel = this[_getPropertyModel]('enabled', BooleanModel, [false, new NotNull()]);
   readonly account: StringModel = this[_getPropertyModel]('account', StringModel, [false, new Size({ max: 150 })]);
   readonly account_resolved: StringModel = this[_getPropertyModel]('account_resolved', StringModel, [true]);
-  readonly imei: StringModel = this[_getPropertyModel]('imei', StringModel, [true]);
+  readonly device_id: StringModel = this[_getPropertyModel]('device_id', StringModel, [true]);
 }
 
 // Validates a TrackerModel using a callback.
@@ -265,10 +265,10 @@ export function validateOgnAccount(id: string): string | false {
   return /^[0-9a-f]{6}$/i.test(id) ? id.toUpperCase() : false;
 }
 
-// Validates a zoleo device ID.
-export function validateZoleoAccount(id: string): string | false {
-  id = id.trim();
-  return id.length > 0 ? id : false;
+// Validates a zoleo IMEI.
+export function validateZoleoAccount(imei: string): string | false {
+  imei = imei.trim();
+  return /^\d{15}$/i.test(imei) ? imei : false;
 }
 
 // Validates a XContest UUID.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-lit": "^2.3.1",
     "eslint-plugin-require-node-import-prefix": "^0.0.2",
     "eslint-plugin-simple-import-sort": "^14.0.0",
+    "eslint-plugin-unused-imports": "catalog:",
     "eslint-plugin-wc": "^3.1.0",
     "jiti": "2.7.0",
     "jsdom": "^30.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ catalogs:
     date-fns:
       specifier: ^4.4.0
       version: 4.4.0
+    eslint-plugin-unused-imports:
+      specifier: ^4.4.1
+      version: 4.4.1
     express:
       specifier: ^5.2.1
       version: 5.2.1
@@ -259,6 +262,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^14.0.0
         version: 14.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-unused-imports:
+        specifier: 'catalog:'
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-wc:
         specifier: ^3.1.0
         version: 3.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
@@ -6090,6 +6096,15 @@ packages:
     resolution: {integrity: sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ==}
     peerDependencies:
       eslint: '>=5.0.0'
+
+  eslint-plugin-unused-imports@4.4.1:
+    resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^10.0.0 || ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-plugin-wc@3.1.0:
     resolution: {integrity: sha512-spvXHD2/GTTgYXxFB3xlMThnXGUeNJaiCwWuPGzjDOLXnVGLcQpDt0fyiN6yiLoaLs/yhsj+7G1FpBZKeigCSA==}
@@ -13824,7 +13839,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
@@ -13841,7 +13856,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.69.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.69.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.69.0
@@ -13883,7 +13898,7 @@ snapshots:
   '@typescript-eslint/type-utils@8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
@@ -13911,9 +13926,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.69.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.69.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
@@ -13942,7 +13957,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -15715,6 +15730,12 @@ snapshots:
   eslint-plugin-simple-import-sort@14.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
+    dependencies:
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
 
   eslint-plugin-wc@3.1.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
@@ -19314,7 +19335,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser': 8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.69.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,7 @@ catalog:
   '@preact/preset-vite': ^2.10.6
   vite-plugin-static-copy: ^4.1.1
   wrangler: ^4.129.0
+  eslint-plugin-unused-imports: ^4.4.1
 
 allowBuilds:
   '@parcel/watcher': false


### PR DESCRIPTION
## Summary by Sourcery

Use Zoleo IMEIs as tracker accounts while retaining device IDs for device linking and consent handling.

Bug Fixes:
- Use the Zoleo IMEI as the tracker account so incoming messages and locations are matched to the correct device.

Enhancements:
- Separate the Zoleo device ID used for linking from the IMEI used for tracking and update the frontend, server, models, and validation to reflect the new fields.

Build:
- Add ESLint unused-import detection and its dependency.

Tests:
- Update Zoleo parsing, synchronization, and model validation tests for IMEI-based account matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated ZOLEO device linking to use device IDs while storing the associated 15-digit IMEI as the account identifier.
  * Improved link and unlink state handling so settings update immediately and remain consistent when saved.
  * Updated live tracking to associate incoming location data with devices using IMEI identifiers.
  * Added validation requiring ZOLEO account identifiers to be 15-digit numeric values.
* **Maintenance**
  * Added automatic detection of unused imports during linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->