### PR TITLE
fix(zoleo): do not allow the form to override id/imei

### DIFF
--- a/apps/fxc-front/src/app/pages/settings.ts
+++ b/apps/fxc-front/src/app/pages/settings.ts
@@ -310,14 +310,10 @@ export class SettingsPage extends LitElement {
    * POST a request to the server to unlink the Zoleo device.
    */
   private async unlinkZoleo() {
-    // Clear the form model so the UI immediately shows "Link a device" and any subsequent
-    // form save preserves the unlinked state.
     const deviceIdNode = this.binder.for(this.binder.model.zoleo.device_id);
     deviceIdNode.value = '';
-    deviceIdNode.visited = true;
     const accountNode = this.binder.for(this.binder.model.zoleo.account);
     accountNode.value = '';
-    accountNode.visited = true;
     await fetchResponse(`${import.meta.env.VITE_API_SERVER}/api/zoleo/unlink`, {
       method: 'POST',
       credentials: 'include',
@@ -414,9 +410,7 @@ export class SettingsPage extends LitElement {
 
       if (linked) {
         deviceIdNode.value = partnerDeviceID;
-        deviceIdNode.visited = true;
         accountNode.value = '';
-        accountNode.visited = true;
 
         const alert = await alertController.create({
           header: 'zoleo',
@@ -431,9 +425,7 @@ export class SettingsPage extends LitElement {
         await alert.present();
       } else {
         deviceIdNode.value = '';
-        deviceIdNode.visited = true;
         accountNode.value = '';
-        accountNode.visited = true;
         const alert = await alertController.create({
           header: 'zoleo',
           message: 'Failed to link your Zoleo device. Please try again.',

--- a/libs/common-node/src/lib/live-track-entity.test.ts
+++ b/libs/common-node/src/lib/live-track-entity.test.ts
@@ -1,0 +1,83 @@
+import type { LiveTrackEntity } from '@flyxc/common';
+import { AccountFormModel } from '@flyxc/common';
+import { describe, expect, it } from 'vitest';
+
+import { updateLiveTrackEntityFromModel } from './live-track-entity';
+
+describe('updateLiveTrackEntityFromModel', () => {
+  it('should preserve zoleo account and device_id from existing entity', () => {
+    const existingEntity = {
+      email: 'pilot@example.com',
+      google_id: 'google-123',
+      name: 'Pilot Name',
+      share: true,
+      enabled: true,
+      zoleo: {
+        enabled: true,
+        account: '300434064660820',
+        device_id: 'c5acc06a-c6f0-40c2-8987-e1a5ac53f6d9',
+      },
+    } as unknown as LiveTrackEntity;
+
+    const accountModel = AccountFormModel.createEmptyValue();
+    accountModel.name = 'Updated Name';
+    accountModel.enabled = true;
+    accountModel.zoleo = {
+      enabled: false,
+      account: '',
+      device_id: '',
+    };
+
+    const updated = updateLiveTrackEntityFromModel(existingEntity, accountModel, 'pilot@example.com', 'google-123');
+
+    expect(updated.name).toBe('Updated Name');
+    expect(updated.zoleo?.enabled).toBe(false);
+    expect(updated.zoleo?.account).toBe('300434064660820');
+    expect(updated.zoleo?.device_id).toBe('c5acc06a-c6f0-40c2-8987-e1a5ac53f6d9');
+  });
+
+  it('should handle undefined existing zoleo entity', () => {
+    const existingEntity = {
+      email: 'pilot@example.com',
+      google_id: 'google-123',
+      name: 'Pilot Name',
+      share: true,
+      enabled: true,
+    } as unknown as LiveTrackEntity;
+
+    const accountModel = AccountFormModel.createEmptyValue();
+    accountModel.name = 'Pilot Name';
+    accountModel.zoleo = {
+      enabled: true,
+      account: 'dummy-ignored',
+    };
+
+    const updated = updateLiveTrackEntityFromModel(existingEntity, accountModel, 'pilot@example.com', 'google-123');
+
+    expect(updated.zoleo?.enabled).toBe(true);
+    expect(updated.zoleo?.account).toBe('');
+    expect(updated.zoleo?.device_id).toBe('');
+  });
+
+  it('should initialize a new entity when existingEntity is undefined', () => {
+    const accountModel = AccountFormModel.createEmptyValue();
+    accountModel.name = 'New Pilot';
+    accountModel.enabled = true;
+    accountModel.zoleo = {
+      enabled: true,
+      account: 'dummy-ignored',
+      device_id: 'dummy-ignored-id',
+    };
+
+    const updated = updateLiveTrackEntityFromModel(undefined, accountModel, 'new@example.com', 'google-456');
+
+    expect(updated.email).toBe('new@example.com');
+    expect(updated.google_id).toBe('google-456');
+    expect(updated.created).toBeInstanceOf(Date);
+    expect(updated.updated).toBeInstanceOf(Date);
+    expect(updated.name).toBe('New Pilot');
+    expect(updated.zoleo?.enabled).toBe(true);
+    expect(updated.zoleo?.account).toBe('');
+    expect(updated.zoleo?.device_id).toBe('');
+  });
+});

--- a/libs/common-node/src/lib/live-track-entity.ts
+++ b/libs/common-node/src/lib/live-track-entity.ts
@@ -23,43 +23,69 @@ export async function retrieveLiveTrackById(datastore: Datastore, id: string): P
   return entity;
 }
 
-// Updates a live track entity with user edits.
+/**
+ * Updates a Datastore `LiveTrackEntity` with data from a user-submitted `AccountModel` (or initializes a new one).
+ *
+ * **What it does**:
+ * - Populates or updates basic account properties (`name`, `share`, `enabled`, and `updated` timestamp;
+ *   sets `email`, `google_id`, and `created` timestamp when creating a new entity).
+ * - Copies `enabled` and `account` settings for each supported tracker.
+ * - Handles `zoleo` specially: only updates its `enabled` status while preserving existing `account` (IMEI)
+ *   and `device_id`, since Zoleo device linking is handled out-of-band via dedicated `/api/zoleo/link`,
+ *   `/api/zoleo/unlink`, and push consent webhooks.
+ *
+ * **When it is called**:
+ * - Called by the server in `createOrUpdateLiveTrack` when processing user settings form submissions
+ *   (`POST /api/live/account.json`), right after form validation and immediately before saving the entity
+ *   to Datastore and notifying the fetcher to sync.
+ *
+ * @param entity - The existing Datastore entity, or `undefined` if this is the user's first time saving settings.
+ * @param accountModel - The validated account settings submitted from the client.
+ * @param email - The authenticated user's email address.
+ * @param googleId - The authenticated user's Google OAuth ID (subject).
+ * @returns The updated `LiveTrackEntity` ready to be saved to Datastore.
+ */
 export function updateLiveTrackEntityFromModel(
   entity: LiveTrackEntity | undefined,
-  account: AccountModel,
+  accountModel: AccountModel,
   email: string,
   googleId: string,
 ): LiveTrackEntity {
-  const liveTrack: Partial<LiveTrackEntity> = entity ?? {
+  entity ??= {
     email,
     google_id: googleId,
     created: new Date(),
-  };
+  } as LiveTrackEntity;
 
   // Update the entity.
-  liveTrack.name = account.name;
-  liveTrack.share = account.share;
-  liveTrack.enabled = account.enabled;
-  liveTrack.updated = new Date();
+  entity.name = accountModel.name;
+  entity.share = accountModel.share;
+  entity.enabled = accountModel.enabled;
+  entity.updated = new Date();
 
-  for (const tracker of trackerNames) {
-    const model = account[tracker];
-    // Preserve the current zoleo device ID.
-    let deviceId: string | undefined;
-    if (tracker == 'zoleo') {
-      deviceId = model.device_id ?? liveTrack[tracker]?.device_id ?? '';
-    }
-    liveTrack[tracker] = {
-      enabled: model.enabled,
-      account: model.account,
-    };
-    if (model.account_resolved != null) {
-      liveTrack[tracker].account_resolved = model.account_resolved;
-    }
-    if (deviceId != null) {
-      liveTrack[tracker].device_id = deviceId;
+  for (const trackerName of trackerNames) {
+    const trackerModel = accountModel[trackerName];
+    if (trackerName === 'zoleo') {
+      // Zoleo account (IMEI) and device_id are managed out-of-band by /link, /unlink, and consent webhooks.
+      // Saving the account form should only update the enabled state and never overwrite account or device_id.
+      entity.zoleo = {
+        account: entity.zoleo?.account ?? '',
+        device_id: entity.zoleo?.device_id ?? '',
+        enabled: trackerModel.enabled,
+      };
+    } else if (trackerName === 'flyme') {
+      entity[trackerName] = {
+        account: trackerModel.account,
+        enabled: trackerModel.enabled,
+        account_resolved: trackerModel.account_resolved ?? '',
+      };
+    } else {
+      entity[trackerName] = {
+        account: trackerModel.account,
+        enabled: trackerModel.enabled,
+      };
     }
   }
 
-  return liveTrack as LiveTrackEntity;
+  return entity;
 }


### PR DESCRIPTION
## Summary by Sourcery

Preserve out-of-band Zoleo linking data when saving account settings.

Bug Fixes:
- Prevent account form submissions from overwriting Zoleo account identifiers and device IDs managed by the linking flow.

Enhancements:
- Preserve Zoleo linking state while updating tracker enablement and retain existing tracker-specific settings during account updates.

Tests:
- Add coverage for preserving Zoleo credentials and initializing Zoleo settings when creating or updating live-track entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Zoleo device linking and unlinking so clearing or setting account and device fields no longer incorrectly triggers visited-state validation messages.
  - Preserved existing Zoleo account and device details when form updates clear those values, preventing unintended data loss.
  - Improved tracker updates so non-Zoleo tracker settings are applied consistently while existing Zoleo details remain intact.
  - Ensured tracker updates retain the appropriate account, device, enabled, and resolution settings across supported tracker types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->